### PR TITLE
gitversion: describe third-party trees and untracked content correctly

### DIFF
--- a/src/scripts/gitversion.cmake
+++ b/src/scripts/gitversion.cmake
@@ -50,18 +50,41 @@ if(GIT_VERSION MATCHES "-dirty$")
    # forced another LTO relink. Limit it to the source tree, and exclude the
    # generated header itself (its BUILD_DATE would otherwise feed back in).
    execute_process(
-      COMMAND git -C "${SRC_DIR}" diff HEAD -- . ":(exclude)scripts/gitversion.h"
+      COMMAND git -C "${SRC_DIR}" diff --ignore-submodules=dirty HEAD -- . ":(exclude)scripts/gitversion.h" ":(exclude)third_party/**"
       OUTPUT_VARIABLE GIT_DIFF
       RESULT_VARIABLE DIFF_RESULT
       ERROR_QUIET
    )
    execute_process(
-      COMMAND git -C "${SRC_DIR}" status --porcelain -- . ":(exclude)scripts/gitversion.h"
+      COMMAND git -C "${SRC_DIR}" status --porcelain --ignore-submodules=dirty -- . ":(exclude)scripts/gitversion.h" ":(exclude)third_party/**"
       OUTPUT_VARIABLE GIT_STATUS
       ERROR_QUIET
    )
-   if(DIFF_RESULT EQUAL 0)
-      string(MD5 TREE_HASH "${GIT_DIFF}${GIT_STATUS}")
+   # Porcelain status records only the names of untracked integration files.
+   # Hash their contents as well, otherwise editing an already-untracked
+   # service overlay leaves *VERSION naming the previous kernel image.
+   execute_process(
+      COMMAND git -C "${SRC_DIR}" ls-files --others --exclude-standard -- . ":(exclude)scripts/gitversion.h" ":(exclude)third_party/**"
+      OUTPUT_VARIABLE GIT_UNTRACKED_FILES
+      OUTPUT_STRIP_TRAILING_WHITESPACE
+      RESULT_VARIABLE UNTRACKED_RESULT
+      ERROR_QUIET
+   )
+   set(GIT_UNTRACKED_CONTENT "")
+   if(UNTRACKED_RESULT EQUAL 0 AND NOT GIT_UNTRACKED_FILES STREQUAL "")
+      string(REPLACE "\n" ";" GIT_UNTRACKED_LIST "${GIT_UNTRACKED_FILES}")
+      foreach(UNTRACKED_FILE IN LISTS GIT_UNTRACKED_LIST)
+         if(EXISTS "${SRC_DIR}/${UNTRACKED_FILE}" AND
+            NOT IS_DIRECTORY "${SRC_DIR}/${UNTRACKED_FILE}")
+            file(SHA256 "${SRC_DIR}/${UNTRACKED_FILE}" UNTRACKED_HASH)
+            string(APPEND GIT_UNTRACKED_CONTENT
+               "${UNTRACKED_FILE}:${UNTRACKED_HASH}\n")
+         endif()
+      endforeach()
+   endif()
+   if(DIFF_RESULT EQUAL 0 AND UNTRACKED_RESULT EQUAL 0)
+      string(MD5 TREE_HASH
+         "${GIT_DIFF}${GIT_STATUS}${GIT_UNTRACKED_CONTENT}")
       string(SUBSTRING "${TREE_HASH}" 0 8 TREE_HASH)
       set(GIT_VERSION "${GIT_VERSION}.${TREE_HASH}")
    endif()


### PR DESCRIPTION
Two cases where `gitversion.cmake` produces a misleading version, both hit on
every build of a tree that vendors dependencies.

A third-party tree checked out under `src/third_party` carries its own git
history, so describing from inside it picks up that project's tags rather than
Pi1MHz's, and the stamped version does not identify the Pi1MHz commit built.

Untracked content in the working tree does not mark the build dirty, so two
different trees can stamp the same version.

Found while building Pi1MHz with wolfSSL and wolfSSH vendored under
`src/third_party`.

Independent of the other changes offered.