### PR TITLE
Add 1MHz-WiFi: WiFi association, network services and a tape filing system

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -36,6 +36,12 @@ project( Pi1MHz C ASM )
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
+# SSH/SFTP needs wolfSSL and wolfSSH under src/third_party, which this
+# repository does not carry and does not fetch.  Default OFF so a plain
+# checkout configures and builds; the 1MHzWifi installer turns it on after
+# installing and verifying the pinned revisions.
+option(PI1MHZ_SSH "Build the SSH/SFTP secure service (needs third_party/wolfssl and wolfssh)" OFF)
+
 # gnu23 is the ratified spelling; gnu2x is the pre-ratification name older
 # compilers still need.  CodeQL autobuilds on ubuntu-latest with whatever GCC
 # the runner ships, so neither can be assumed.
@@ -326,6 +332,7 @@ set(lwip_files
    ${LWIP_ROOT}/src/core/pbuf.c
    ${LWIP_ROOT}/src/core/stats.c
    ${LWIP_ROOT}/src/core/sys.c
+   ${LWIP_ROOT}/src/core/raw.c
    ${LWIP_ROOT}/src/core/tcp.c
    ${LWIP_ROOT}/src/core/tcp_in.c
    ${LWIP_ROOT}/src/core/tcp_out.c
@@ -365,6 +372,7 @@ set_source_files_properties(
    ${LWIP_ROOT}/src/core/pbuf.c
    ${LWIP_ROOT}/src/core/stats.c
    ${LWIP_ROOT}/src/core/sys.c
+   ${LWIP_ROOT}/src/core/raw.c
    ${LWIP_ROOT}/src/core/tcp.c
    ${LWIP_ROOT}/src/core/tcp_in.c
    ${LWIP_ROOT}/src/core/tcp_out.c
@@ -408,6 +416,7 @@ set( Pi1MHz_sources
     ${mouse_redirect_files}
     ${wifi_files}
     ${lwip_files}
+    elkwifi_service.c
 )
 
 # These are cold (config/filename handling, ~12 call sites). We recompile them
@@ -422,9 +431,56 @@ set_source_files_properties(
    lib/newlib-str/strcasestr.c
    PROPERTIES COMPILE_OPTIONS "-Os;-Wno-cast-qual;-Wno-conversion" )
 
+if(PI1MHZ_SSH)
+   if(NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/third_party/wolfssl/CMakeLists.txt"
+      OR NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/third_party/wolfssh/src/ssh.c")
+      message(FATAL_ERROR
+         "PI1MHZ_SSH=ON needs wolfSSL in src/third_party/wolfssl and wolfSSH in "
+         "src/third_party/wolfssh.  Neither is carried or fetched by this "
+         "repository; install the pinned revisions first, or configure with "
+         "-DPI1MHZ_SSH=OFF.")
+   endif()
+
+   list(APPEND Pi1MHz_sources
+      secure_service.c secure_service.h
+      secure_service_core.c secure_service_core.h
+      secure_service_wolfssh.c secure_service_wolfssh.h)
+
+   # Pinned crypto-only wolfCrypt and wolfSSH client. Their source revisions are
+   # installed and verified by the 1MHzWifi Pi1MHz installer.
+   set(BUILD_SHARED_LIBS OFF CACHE BOOL "" FORCE)
+   set(WOLFSSL_USER_SETTINGS yes CACHE STRING "" FORCE)
+   set(WOLFSSL_EXAMPLES no CACHE STRING "" FORCE)
+   set(WOLFSSL_CRYPT_TESTS no CACHE STRING "" FORCE)
+   add_subdirectory(third_party/wolfssl wolfssl-build EXCLUDE_FROM_ALL)
+   target_include_directories(wolfssl PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+   target_compile_options(wolfssl PRIVATE -w -Os -fno-lto)
+
+   add_library(nettools_wolfssh STATIC
+      third_party/wolfssh/src/ssh.c
+      third_party/wolfssh/src/internal.c
+      third_party/wolfssh/src/log.c
+      third_party/wolfssh/src/io.c
+      third_party/wolfssh/src/port.c
+      third_party/wolfssh/src/wolfterm.c
+      third_party/wolfssh/src/ossh.c
+      third_party/wolfssh/src/wolfsftp.c)
+   target_include_directories(nettools_wolfssh PUBLIC
+      third_party/wolfssh third_party/wolfssl ${CMAKE_CURRENT_SOURCE_DIR}
+      ${CMAKE_CURRENT_SOURCE_DIR}/BeebSCSI/fatfs)
+   target_compile_definitions(nettools_wolfssh PRIVATE
+      BUILDING_WOLFSSH WOLFSSL_USER_SETTINGS)
+   target_compile_options(nettools_wolfssh PRIVATE -w -Os -fno-lto)
+   target_link_libraries(nettools_wolfssh PUBLIC wolfssl)
+endif()
+
 add_executable( Pi1MHz ${Pi1MHz_sources} )
 
 target_link_libraries( Pi1MHz PRIVATE m )
+if(PI1MHZ_SSH)
+   target_compile_definitions(Pi1MHz PRIVATE WOLFSSL_USER_SETTINGS PI1MHZ_SSH)
+   target_link_libraries( Pi1MHz PRIVATE nettools_wolfssh wolfssl )
+endif()
 
 # Kernel images always go to the top-level firmware/ directory, regardless of
 # where the build directory is (so out-of-source build/<config> dirs work).

--- a/src/Pi1MHz.c
+++ b/src/Pi1MHz.c
@@ -124,6 +124,8 @@ See mdfs.net/Docs/Comp/BBC/Hardware/JIMAddrs for full details
 #include "videoplayer.h"
 #include "usb.h"
 #include "wifi/wifi.h"
+#include "elkwifi_service.h"
+#include "secure_service.h"
 #include "AUN/aun_emulator.h"
 #include "teletext_emulator.h"
 #include "watchdog.h"
@@ -156,6 +158,10 @@ static emulator_list emulator[] = {
       its poll runs once lwIP has drained inbound frames; off unless
       net_enable=1 in Pi1MHz.cfg. */
    {"net",net_service_init, 0x00, 1 },
+   {"ElkWiFi",elkwifi_service_init, 0x00, 1 },
+#ifdef PI1MHZ_SSH
+   {"secure",secure_service_init, 0x00, 1 },
+#endif
    {"Teletext",teletext_emulator_init, 0x10, 1 },  // Acorn Teletext Adapter at &FC10
    /* Last, so its poll callback re-arms the watchdog only after every other
       emulator has had its turn - a poll that stops responding still trips it. */

--- a/src/elkwifi_service.c
+++ b/src/elkwifi_service.c
@@ -1,0 +1,945 @@
+/* Pi1MHz-side service for the ElkWiFi-compatible ROM.
+ *
+ * The AP5 passes &FCA0-&FCAF, &FCFF and JIM to its 1 MHz connector. Pi1MHz's
+ * existing services mailbox at &FCA6 therefore works on an unmodified AP5;
+ * the original cartridge UART at &FC30 does not. Slow work is latched in FIQ
+ * and completed from the main poll loop.
+ */
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdarg.h>
+#include <string.h>
+#include <strings.h>
+
+#include "Pi1MHz.h"
+#include "scripts/gitversion.h"
+#include "BeebSCSI/filesystem.h"
+#include "config.h"
+#include "elkwifi_service.h"
+#include "ram_emulator.h"
+#include "services.h"
+#include "wifi/sdio.h"
+#include "wifi/wifi.h"
+#include "wifi/wifi_lwip.h"
+#include "rpi/systimer.h"
+#include "rpi/asm-helpers.h"
+#include "lwip/def.h"
+#include "lwip/dns.h"
+#include "lwip/inet_chksum.h"
+#include "lwip/pbuf.h"
+#include "lwip/prot/icmp.h"
+#include "lwip/raw.h"
+#include "lwip/udp.h"
+
+#define ELKWIFI_TEXT_MAX 240u
+#define WIFI_FILE "/Pi1MHz/ElkWiFi.wifi"
+#define WIFI_PROFILE_HEADER "ELKWIFI1"
+#define LAPOPT_FILE "/Pi1MHz/ElkWiFi.lapopt"
+/* AP5 exposes the standard 64K JIM window selected by &FCFF. It does not
+ * forward Pi1MHz's extension selectors at &FCFD/&FCFE. Keep UEF data in the
+ * first 64K so the host and Pi always refer to the same physical bytes. */
+/* Every JIM page carries the host's filing-vector trampoline at the same
+ * offset, so a vector entry point is reachable whatever the page selector
+ * holds. The host's RAM gateway below &0800 and the MOS extended vector
+ * table at &0D9F are both inside the region cassette loaders reuse; JIM is
+ * not, because the Pi serves it. The published stream therefore stops at
+ * the trampoline, leaving 160 bytes per page, and &FDF0-&FDFF stays clear
+ * for the stream length trailer in the last two bytes of page &FF. */
+/* JIM page 0 belongs to the host's service reply buffer, which ElkChat and
+ * other OSWORD &65 clients read as up to 241 contiguous bytes. Publishing
+ * the stream from page 1 keeps the two apart, so a reply arriving while a
+ * UEF is being read can no longer overwrite bytes WiCFS has not reached:
+ * an "ERR" reply used to be read back as chunk type &5245. */
+/* The flat window reserves page 0 for the service reply buffer, which the
+ * OSWORD &65 clients read in full, and the last page for the length trailer. */
+/* A published guard occupies the top of every page, so the stream gives those
+ * bytes up and is laid out in short runs instead. The guard ends exactly at
+ * the page top, which is what leaves the length trailer intact. */
+#define ELKWIFI_VERSION_RESPONSE \
+   "Pi1MHz ElkWiFi 0.1.67, kernel " GITVERSION "\r\n\r\nOK\r\n"
+
+_Static_assert(ELKWIFI_CMD_FIRST == SERVICE_CMD_ELKWIFI_FIRST,
+               "ElkWiFi service range start disagrees with services.h");
+_Static_assert(ELKWIFI_CMD_LAST == SERVICE_CMD_ELKWIFI_LAST,
+               "ElkWiFi service range end disagrees with services.h");
+
+static volatile bool request_pending;
+static volatile bool request_cancel;
+static volatile uint32_t request_pointer;
+static volatile uint32_t request_status_address;
+static bool service_initialised;
+static bool scan_waiting;
+static uint8_t scan_fields = 127u;
+
+typedef enum {
+   NETOP_IDLE = 0,
+   NETOP_DNS,
+   NETOP_WAITING,
+   NETOP_DONE,
+   NETOP_FAILED
+} netop_state_t;
+
+#define ELKWIFI_NET_TIMEOUT_US 4000000u
+#define ELKWIFI_PING_ID 0x454cu
+#define NTP_UNIX_EPOCH 2208988800u
+
+static netop_state_t ping_state;
+static struct raw_pcb *ping_pcb;
+static ip_addr_t ping_address;
+static char ping_host[ELKWIFI_TEXT_MAX + 1u];
+static uint16_t ping_sequence;
+static uint32_t ping_started_us;
+static uint32_t ping_deadline_us;
+static uint32_t ping_elapsed_ms;
+static uint32_t ping_generation;
+
+static netop_state_t time_state;
+static struct udp_pcb *time_pcb;
+static ip_addr_t time_address;
+static uint32_t time_deadline_us;
+static uint32_t time_ntp_seconds;
+static int16_t time_utc_offset_minutes;
+static uint32_t time_generation;
+
+static void response_string(uint32_t cp, const char *value);
+static void response_printf(uint32_t cp, const char *format, ...)
+   __attribute__((format(printf, 2, 3)));
+static bool command_string(uint32_t cp, const char **value);
+
+
+
+
+
+
+
+
+
+
+
+
+
+static bool deadline_expired(uint32_t deadline)
+{
+   return (int32_t)(RPI_GetSystemTime() - deadline) >= 0;
+}
+
+static void ping_close(void)
+{
+   if (ping_pcb != NULL) {
+      raw_remove(ping_pcb);
+      ping_pcb = NULL;
+   }
+}
+
+static void time_close(void)
+{
+   if (time_pcb != NULL) {
+      udp_remove(time_pcb);
+      time_pcb = NULL;
+   }
+}
+
+static void asynchronous_close(void)
+{
+   /* Invalidate DNS/packet callbacks before releasing their PCBs. A late
+      callback from a cancelled request must never complete a newer command
+      which has reused the same static state. */
+   ping_generation++;
+   time_generation++;
+   ping_close();
+   ping_state = NETOP_IDLE;
+   time_close();
+   time_state = NETOP_IDLE;
+   sdio_runtime_scan_cancel();
+   scan_waiting = false;
+}
+
+static u8_t ping_receive(void *arg, struct raw_pcb *pcb, struct pbuf *p,
+                         const ip_addr_t *address)
+{
+   uint8_t first;
+   uint16_t ip_header_length;
+   struct icmp_echo_hdr echo;
+   (void)pcb;
+   (void)address;
+   if ((uint32_t)(uintptr_t)arg != ping_generation
+       || ping_state != NETOP_WAITING || p == NULL || p->tot_len < 28u)
+      return 0u;
+   if (pbuf_copy_partial(p, &first, 1u, 0u) != 1u)
+      return 0u;
+   ip_header_length = (uint16_t)((first & 0x0fu) * 4u);
+   if (ip_header_length < 20u
+       || pbuf_copy_partial(p, &echo, sizeof echo, ip_header_length) != sizeof echo)
+      return 0u;
+   if (ICMPH_TYPE(&echo) != ICMP_ER || echo.id != ELKWIFI_PING_ID
+       || echo.seqno != lwip_htons(ping_sequence))
+      return 0u;
+   ping_elapsed_ms = (RPI_GetSystemTime() - ping_started_us + 500u) / 1000u;
+   ping_state = NETOP_DONE;
+   pbuf_free(p);
+   return 1u;
+}
+
+static void ping_send(void)
+{
+   struct pbuf *p;
+   struct icmp_echo_hdr *echo;
+   const uint16_t length = (uint16_t)(sizeof(*echo) + 24u);
+   ping_pcb = raw_new(IP_PROTO_ICMP);
+   if (ping_pcb == NULL) {
+      ping_state = NETOP_FAILED;
+      return;
+   }
+   raw_recv(ping_pcb, ping_receive, (void *)(uintptr_t)ping_generation);
+   raw_bind(ping_pcb, IP_ADDR_ANY);
+   p = pbuf_alloc(PBUF_IP, length, PBUF_RAM);
+   if (p == NULL || p->len != p->tot_len) {
+      if (p != NULL) pbuf_free(p);
+      ping_close();
+      ping_state = NETOP_FAILED;
+      return;
+   }
+   echo = (struct icmp_echo_hdr *)p->payload;
+   memset(echo, 0, length);
+   ICMPH_TYPE_SET(echo, ICMP_ECHO);
+   ICMPH_CODE_SET(echo, 0u);
+   echo->id = ELKWIFI_PING_ID;
+   echo->seqno = lwip_htons(++ping_sequence);
+   for (uint16_t i = sizeof(*echo); i < length; i++)
+      ((uint8_t *)echo)[i] = (uint8_t)i;
+   echo->chksum = inet_chksum(echo, length);
+   ping_started_us = RPI_GetSystemTime();
+   if (raw_sendto(ping_pcb, p, &ping_address) != ERR_OK) {
+      pbuf_free(p);
+      ping_close();
+      ping_state = NETOP_FAILED;
+      return;
+   }
+   pbuf_free(p);
+   ping_state = NETOP_WAITING;
+   wifi_lwip_rx_kick();
+}
+
+static void ping_dns_found(const char *name, const ip_addr_t *address, void *arg)
+{
+   (void)name;
+   if ((uint32_t)(uintptr_t)arg != ping_generation
+       || ping_state != NETOP_DNS)
+      return;
+   if (address == NULL) {
+      ping_state = NETOP_FAILED;
+      return;
+   }
+   ip_addr_copy(ping_address, *address);
+   ping_send();
+}
+
+static uint8_t wifi_ping(uint32_t cp)
+{
+   const char *host;
+   if (ping_state == NETOP_IDLE) {
+      err_t result;
+      if (!sdio_runtime_link_is_up() || !command_string(cp, &host)
+          || host[0] == '\0')
+         return ELKWIFI_ERR_NETWORK;
+      strlcpy(ping_host, host, sizeof ping_host);
+      ping_generation++;
+      ping_deadline_us = RPI_GetSystemTime() + ELKWIFI_NET_TIMEOUT_US;
+      result = dns_gethostbyname(ping_host, &ping_address, ping_dns_found,
+                                 (void *)(uintptr_t)ping_generation);
+      if (result == ERR_OK)
+         ping_send();
+      else if (result == ERR_INPROGRESS)
+         ping_state = NETOP_DNS;
+      else
+         ping_state = NETOP_FAILED;
+   }
+   if ((ping_state == NETOP_DNS || ping_state == NETOP_WAITING)
+       && deadline_expired(ping_deadline_us)) {
+      ping_close();
+      ping_state = NETOP_IDLE;
+      response_string(cp, "+timeout\r\n");
+      return ELKWIFI_OK;
+   }
+   if (ping_state == NETOP_DONE) {
+      ping_close();
+      ping_state = NETOP_IDLE;
+      response_printf(cp, "+%lu\r\n", (unsigned long)ping_elapsed_ms);
+      return ELKWIFI_OK;
+   }
+   if (ping_state == NETOP_FAILED) {
+      ping_close();
+      ping_state = NETOP_IDLE;
+      return ELKWIFI_ERR_NETWORK;
+   }
+   return ELKWIFI_BUSY;
+}
+
+static void time_udp_receive(void *arg, struct udp_pcb *pcb, struct pbuf *p,
+                             const ip_addr_t *address, u16_t port)
+{
+   uint8_t packet[48];
+   (void)pcb;
+   (void)address;
+   if ((uint32_t)(uintptr_t)arg == time_generation
+       && time_state == NETOP_WAITING && p != NULL && port == 123u
+       && p->tot_len >= sizeof packet
+       && pbuf_copy_partial(p, packet, sizeof packet, 0u) == sizeof packet
+       && (packet[0] & 7u) == 4u && packet[1] != 0u) {
+      time_ntp_seconds = ((uint32_t)packet[40] << 24)
+                       | ((uint32_t)packet[41] << 16)
+                       | ((uint32_t)packet[42] << 8) | packet[43];
+      time_state = time_ntp_seconds >= NTP_UNIX_EPOCH ? NETOP_DONE : NETOP_FAILED;
+   }
+   if (p != NULL) pbuf_free(p);
+}
+
+static void time_send(void)
+{
+   uint8_t packet[48] = {0};
+   struct pbuf *p;
+   time_pcb = udp_new();
+   if (time_pcb == NULL) {
+      time_state = NETOP_FAILED;
+      return;
+   }
+   udp_recv(time_pcb, time_udp_receive, (void *)(uintptr_t)time_generation);
+   packet[0] = 0x1bu;
+   p = pbuf_alloc(PBUF_TRANSPORT, sizeof packet, PBUF_RAM);
+   if (p == NULL || pbuf_take(p, packet, sizeof packet) != ERR_OK
+       || udp_sendto(time_pcb, p, &time_address, 123u) != ERR_OK) {
+      if (p != NULL) pbuf_free(p);
+      time_state = NETOP_FAILED;
+      return;
+   }
+   pbuf_free(p);
+   time_state = NETOP_WAITING;
+   wifi_lwip_rx_kick();
+}
+
+static void time_dns_found(const char *name, const ip_addr_t *address, void *arg)
+{
+   (void)name;
+   if ((uint32_t)(uintptr_t)arg != time_generation
+       || time_state != NETOP_DNS)
+      return;
+   if (address == NULL) {
+      time_state = NETOP_FAILED;
+      return;
+   }
+   ip_addr_copy(time_address, *address);
+   time_send();
+}
+
+static bool leap_year(uint32_t year)
+{
+   return (year % 4u == 0u && year % 100u != 0u) || year % 400u == 0u;
+}
+
+static int16_t utc_offset_parse(const char *value)
+{
+   bool negative = false;
+   int32_t parsed = 0;
+   if (value == NULL || value[0] == '\0') return 0;
+   if (*value == '+' || *value == '-') {
+      negative = *value == '-';
+      value++;
+   }
+   if (*value == '\0') return 0;
+   while (*value != '\0') {
+      if (*value < '0' || *value > '9') return 0;
+      parsed = parsed * 10 + (*value++ - '0');
+      if (parsed > 14 * 60) return 0;
+   }
+   return (int16_t)(negative ? -parsed : parsed);
+}
+
+
+static void format_network_time(uint32_t cp, bool date)
+{
+   static const uint8_t month_days[] = {31,28,31,30,31,30,31,31,30,31,30,31};
+   int64_t adjusted = (int64_t)(time_ntp_seconds - NTP_UNIX_EPOCH)
+                    + (int64_t)time_utc_offset_minutes * 60;
+   uint32_t seconds = adjusted < 0 ? 0u : (uint32_t)adjusted;
+   uint32_t days = seconds / 86400u;
+   uint32_t year = 1970u;
+   uint32_t month = 0u;
+   while (days >= (leap_year(year) ? 366u : 365u))
+      days -= leap_year(year++) ? 366u : 365u;
+   while (month < 11u) {
+      uint32_t length = month_days[month] + ((month == 1u && leap_year(year)) ? 1u : 0u);
+      if (days < length) break;
+      days -= length;
+      month++;
+   }
+   if (date)
+      response_printf(cp, "%02lu-%02lu-%04lu\r\n", (unsigned long)(days + 1u),
+                      (unsigned long)(month + 1u), (unsigned long)year);
+   else {
+      seconds %= 86400u;
+      response_printf(cp, "%02lu:%02lu:%02lu\r\n",
+                      (unsigned long)(seconds / 3600u),
+                      (unsigned long)((seconds / 60u) % 60u),
+                      (unsigned long)(seconds % 60u));
+   }
+}
+
+static uint8_t wifi_datetime(uint32_t cp)
+{
+   bool date = Pi1MHz->JIM_ram[cp + 1u] == 0u;
+   if (time_state == NETOP_IDLE) {
+      err_t result;
+      if (!sdio_runtime_link_is_up()) return ELKWIFI_ERR_NETWORK;
+      time_generation++;
+      time_deadline_us = RPI_GetSystemTime() + ELKWIFI_NET_TIMEOUT_US;
+      result = dns_gethostbyname("pool.ntp.org", &time_address,
+                                 time_dns_found,
+                                 (void *)(uintptr_t)time_generation);
+      if (result == ERR_OK) time_send();
+      else if (result == ERR_INPROGRESS) time_state = NETOP_DNS;
+      else time_state = NETOP_FAILED;
+   }
+   if ((time_state == NETOP_DNS || time_state == NETOP_WAITING)
+       && deadline_expired(time_deadline_us))
+      time_state = NETOP_FAILED;
+   if (time_state == NETOP_DONE) {
+      time_close();
+      format_network_time(cp, date);
+      time_state = NETOP_IDLE;
+      return ELKWIFI_OK;
+   }
+   if (time_state == NETOP_FAILED) {
+      time_close();
+      time_state = NETOP_IDLE;
+      return ELKWIFI_ERR_NETWORK;
+   }
+   return ELKWIFI_BUSY;
+}
+
+static const char *security_name(wifi_security_t security)
+{
+   switch (security) {
+      case WIFI_SECURITY_OPEN: return "OPEN";
+      case WIFI_SECURITY_WEP: return "WEP";
+      case WIFI_SECURITY_WPA: return "WPA";
+      case WIFI_SECURITY_WPA2: return "WPA2";
+      case WIFI_SECURITY_AUTO:
+      default: return "AUTO";
+   }
+}
+
+static bool security_parse(const char *value, wifi_security_t *security)
+{
+   if (strcasecmp(value, "AUTO") == 0) *security = WIFI_SECURITY_AUTO;
+   else if (strcasecmp(value, "OPEN") == 0) *security = WIFI_SECURITY_OPEN;
+   else if (strcasecmp(value, "WEP") == 0) *security = WIFI_SECURITY_WEP;
+   else if (strcasecmp(value, "WPA") == 0) *security = WIFI_SECURITY_WPA;
+   else if (strcasecmp(value, "WPA2") == 0) *security = WIFI_SECURITY_WPA2;
+   else return false;
+   return true;
+}
+
+/* The stock two-argument command remains *JOIN ssid password and selects
+ * WPA/WPA2 automatically.  A mode prefix is additive and needs no ROM ABI
+ * change: OPEN, WEP:key, WPA:passphrase, WPA2:passphrase or AUTO:passphrase. */
+static bool join_password_parse(const char *input, const char **password,
+                                wifi_security_t *security)
+{
+   static const struct { const char *prefix; wifi_security_t security; } modes[] = {
+      { "AUTO:", WIFI_SECURITY_AUTO }, { "WPA:", WIFI_SECURITY_WPA },
+      { "WPA2:", WIFI_SECURITY_WPA2 }, { "WEP:", WIFI_SECURITY_WEP }
+   };
+   if (strcasecmp(input, "OPEN") == 0) {
+      *password = "";
+      *security = WIFI_SECURITY_OPEN;
+      return true;
+   }
+   for (size_t i = 0u; i < sizeof modes / sizeof modes[0]; i++) {
+      size_t length = strlen(modes[i].prefix);
+      if (strncasecmp(input, modes[i].prefix, length) == 0) {
+         *password = input + length;
+         *security = modes[i].security;
+         return true;
+      }
+   }
+   *password = input;
+   *security = WIFI_SECURITY_AUTO;
+   return true;
+}
+
+/* Load the credentials saved by *JOIN before the cooperative WiFi boot state
+ * machine gets its first poll.  wifi_reconfigure_and_rejoin() also handles
+ * the no-Pi1MHz.cfg-SSID case by scheduling initial SDIO bring-up. */
+static void wifi_credentials_load(void)
+{
+   uint8_t storage[WIFI_SSID_MAX_LEN + WIFI_PASSWORD_MAX_LEN + 32u];
+   uint8_t *data = storage;
+   uint32_t length = filesystemReadFile(WIFI_FILE, &data,
+                                        (unsigned int)(sizeof storage - 1u));
+   uint32_t split = 0u;
+   wifi_security_t security = WIFI_SECURITY_AUTO;
+   const char *ssid;
+   const char *password;
+
+   if (length == 0u || length >= sizeof storage)
+      return;
+   data[length] = '\0';
+   while (split < length && data[split] != '\r' && data[split] != '\n')
+      split++;
+   if (split == 0u || split == length)
+      return;
+   data[split++] = '\0';
+   while (split < length && (data[split] == '\r' || data[split] == '\n'))
+      split++;
+   ssid = (const char *)data;
+   if (strcmp(ssid, WIFI_PROFILE_HEADER) == 0) {
+      uint32_t mode_end = split;
+      while (mode_end < length && data[mode_end] != '\r' && data[mode_end] != '\n')
+         mode_end++;
+      if (mode_end == length) return;
+      data[mode_end++] = '\0';
+      if (!security_parse((const char *)&data[split], &security)) return;
+      while (mode_end < length && (data[mode_end] == '\r' || data[mode_end] == '\n'))
+         mode_end++;
+      ssid = (const char *)&data[mode_end];
+      split = mode_end;
+      while (split < length && data[split] != '\r' && data[split] != '\n') split++;
+      if (split == length) return;
+      data[split++] = '\0';
+      while (split < length && (data[split] == '\r' || data[split] == '\n')) split++;
+   }
+   if (strlen(ssid) == 0u || strlen(ssid) > WIFI_SSID_MAX_LEN) return;
+   {
+      uint32_t end = split;
+      while (end < length && data[end] != '\r' && data[end] != '\n')
+         end++;
+      if (end - split > WIFI_PASSWORD_MAX_LEN)
+         return;
+      data[end] = '\0';
+   }
+   password = (const char *)&data[split];
+   /* A BBC/Electron reset re-registers this service but does not reset the
+    * Pi or CYW43. Do not turn an already-live association into a full rejoin
+    * merely because the saved profile was read again. That rejoin can take
+    * more than a minute on a busy access point and was the slow-reset
+    * regression. Changed credentials still take the normal rejoin path. */
+   if (sdio_runtime_started()) {
+      const wifi_config_t *current = wifi_get_config();
+      if (current != NULL && strcmp(current->ssid, ssid) == 0
+          && strcmp(current->password, password) == 0
+          && current->security == security)
+         return;
+   }
+   (void)wifi_reconfigure_and_rejoin(ssid, password, security);
+}
+
+static void lapopt_load(void)
+{
+   uint8_t storage[8];
+   uint8_t *data = storage;
+   uint32_t length = filesystemReadFile(LAPOPT_FILE, &data,
+                                        (unsigned int)(sizeof storage - 1u));
+   if (length == 0u || length >= sizeof storage)
+      return;
+   data[length] = '\0';
+   while (length != 0u && (data[length - 1u] == '\r' || data[length - 1u] == '\n'))
+      data[--length] = '\0';
+   if (strcmp((const char *)data, "7") == 0)
+      scan_fields = 7u;
+   else if (strcmp((const char *)data, "127") == 0)
+      scan_fields = 127u;
+}
+
+static void response_printf(uint32_t cp, const char *format, ...)
+{
+   char value[ELKWIFI_TEXT_MAX + 1u];
+   va_list args;
+   va_start(args, format);
+   int length = vsnprintf(value, sizeof value, format, args);
+   va_end(args);
+   if (length < 0)
+      value[0] = '\0';
+   value[ELKWIFI_TEXT_MAX] = '\0';
+   response_string(cp, value);
+}
+
+static void ip_text(char out[16], const wifi_ipv4_addr_t *ip)
+{
+   (void)snprintf(out, 16u, "%u.%u.%u.%u", (unsigned)ip->octets[0],
+                  (unsigned)ip->octets[1], (unsigned)ip->octets[2],
+                  (unsigned)ip->octets[3]);
+}
+
+static bool two_strings(uint32_t start, const char **first, const char **second)
+{
+   uint32_t limit = DISC_RAM_BASE + DISC_RAM_SIZE;
+   uint32_t end = start;
+   if (start >= limit)
+      return false;
+   while (end < limit && end - start <= WIFI_SSID_MAX_LEN
+          && Pi1MHz->JIM_ram[end] != 0u)
+      end++;
+   if (end >= limit || end - start > WIFI_SSID_MAX_LEN)
+      return false;
+   *first = (const char *)&Pi1MHz->JIM_ram[start];
+   start = end + 1u;
+   end = start;
+   while (end < limit && end - start <= WIFI_PASSWORD_MAX_LEN
+          && Pi1MHz->JIM_ram[end] != 0u)
+      end++;
+   if (end >= limit || end - start > WIFI_PASSWORD_MAX_LEN)
+      return false;
+   *second = (const char *)&Pi1MHz->JIM_ram[start];
+   return true;
+}
+
+static uint8_t wifi_join(uint32_t cp)
+{
+   const wifi_config_t *config = wifi_get_config();
+   uint8_t operation = Pi1MHz->JIM_ram[cp + 1u];
+
+   /* Stock ROM revisions differ here: some turn JOIN ? into operation zero,
+      while others pass the literal question-mark byte through. Both spell
+      the same standard association query. */
+   if (operation == (uint8_t)'?')
+      operation = ELKWIFI_JOIN_QUERY;
+
+   if (operation == ELKWIFI_JOIN_QUERY) {
+      if (sdio_runtime_rejoin_busy()) {
+         response_string(cp, "WIFI CONNECTING\r\n\r\nOK\r\n");
+         return ELKWIFI_OK;
+      }
+      if (!sdio_runtime_link_is_up()) {
+         response_string(cp, "No AP\r\n\r\nOK\r\n");
+         return ELKWIFI_OK;
+      }
+      response_printf(cp, "+CWJAP:\"%s\"\r\n\r\nOK\r\n", config->ssid);
+      return ELKWIFI_OK;
+   }
+   if (operation == ELKWIFI_JOIN_LEAVE) {
+      if (!wifi_disconnect())
+         return ELKWIFI_ERR_NETWORK;
+      response_string(cp, "WIFI DISCONNECT\r\n\r\nOK\r\n");
+      return ELKWIFI_OK;
+   }
+   if (operation == ELKWIFI_JOIN_RADIO_OFF) {
+      if (!wifi_disable_radio())
+         return ELKWIFI_ERR_NETWORK;
+      response_string(cp, "WIFI OFF\r\n\r\nOK\r\n");
+      return ELKWIFI_OK;
+   }
+   if (operation != ELKWIFI_JOIN_SET)
+      return ELKWIFI_ERR_PARAM;
+
+   const char *ssid;
+   const char *password;
+   wifi_security_t security;
+   if (!two_strings(cp + 2u, &ssid, &password) || ssid[0] == '\0')
+      return ELKWIFI_ERR_PARAM;
+   if (!join_password_parse(password, &password, &security))
+      return ELKWIFI_ERR_PARAM;
+   if (!wifi_profile_is_valid(ssid, password, security))
+      return ELKWIFI_ERR_PARAM;
+   char persisted[WIFI_SSID_MAX_LEN + WIFI_PASSWORD_MAX_LEN + 32u];
+   int length = snprintf(persisted, sizeof persisted, "%s\n%s\n%s\n%s\n",
+                         WIFI_PROFILE_HEADER, security_name(security), ssid, password);
+   if (length < 0 || (size_t)length >= sizeof persisted
+       || filesystemWriteFile(WIFI_FILE, (const uint8_t *)persisted,
+                              (uint32_t)length) != (uint32_t)length)
+      return ELKWIFI_ERR_IO;
+   if (!wifi_reconfigure_and_rejoin(ssid, password, security))
+      return ELKWIFI_ERR_NETWORK;
+   /* Association runs in the cooperative WiFi poll and owns the SDIO runtime
+      for dozens of setup ioctls. Never keep the shared ElkWiFi command page
+      pending across that work: a host timeout followed by LAP/IFCFG would
+      overwrite the still-live JOIN request. Acknowledge the accepted request
+      immediately; JOIN ? and IFCFG expose its live outcome. */
+   response_printf(cp, "WIFI CONNECTING %s\r\n\r\nOK\r\n",
+                   security_name(security));
+   return ELKWIFI_OK;
+}
+
+static uint8_t wifi_ifcfg(uint32_t cp)
+{
+   const wifi_network_config_t *net = wifi_get_network_config();
+   const wifi_lwip_context_t *live = wifi_lwip_get_context();
+   sdio_runtime_status_t radio = sdio_runtime_get_status();
+   uint8_t mac[6] = {0};
+   char ip[16] = "0.0.0.0";
+   if (net->has_address) ip_text(ip, &net->address);
+   /* DHCP owns the live values in lwIP; the parsed configuration object
+      intentionally contains no address in DHCP mode.  Report the netif so
+      *IFCFG changes from zeroes as soon as JOIN has obtained its lease. */
+   if (radio.link_up && live != NULL && live->netif_added) {
+      const ip4_addr_t *live_ip = netif_ip4_addr(&live->netif);
+      (void)snprintf(ip, sizeof ip, "%u.%u.%u.%u", ip4_addr1(live_ip),
+                     ip4_addr2(live_ip), ip4_addr3(live_ip), ip4_addr4(live_ip));
+   }
+   (void)sdio_runtime_get_chip_mac(mac);
+   /* Function 18 is a public ElkWiFi ABI, not the Pi diagnostic surface.
+      Keep it original-compatible and comfortably below the ROM's bounded
+      239-byte mailbox copy. Applications such as ElkChat consume these exact
+      records; Pi-specific link detail is available through *ONLINE. */
+   response_printf(cp,
+      "+CIFSR:STAIP,\"%s\"\r\n+CIFSR:STAMAC,\"%02x:%02x:%02x:%02x:%02x:%02x\"\r\n"
+      "\r\nOK\r\n",
+      ip, (unsigned)mac[0], (unsigned)mac[1], (unsigned)mac[2],
+      (unsigned)mac[3], (unsigned)mac[4], (unsigned)mac[5]);
+   return ELKWIFI_OK;
+}
+
+static uint8_t wifi_online(uint32_t cp)
+{
+   const wifi_lwip_context_t *live = wifi_lwip_get_context();
+   sdio_runtime_status_t radio = sdio_runtime_get_status();
+
+   if (radio.link_up && live != NULL && live->netif_added) {
+      const ip4_addr_t *address = netif_ip4_addr(&live->netif);
+      if (!ip4_addr_isany_val(*address)) {
+         response_printf(cp, "ONLINE %u.%u.%u.%u\r\n",
+                         ip4_addr1(address), ip4_addr2(address),
+                         ip4_addr3(address), ip4_addr4(address));
+         return ELKWIFI_OK;
+      }
+   }
+   if (radio.join_busy || radio.link_up)
+      response_string(cp, "OFFLINE CONNECTING\r\n");
+   else if (wifi_get_state() == WIFI_STATE_DISABLED)
+      response_string(cp, "OFFLINE WIFI OFF\r\n");
+   else if (wifi_get_state() == WIFI_STATE_ERROR)
+      response_string(cp, "OFFLINE ERROR\r\n");
+   else
+      response_string(cp, "OFFLINE\r\n");
+   return ELKWIFI_OK;
+}
+
+static uint8_t wifi_scan(uint32_t cp)
+{
+   sdio_wifi_scan_result_t results[SDIO_WIFI_SCAN_MAX_RESULTS];
+   char response[ELKWIFI_TEXT_MAX + 1u];
+   size_t used = 0u;
+
+   if (!scan_waiting) {
+      if (!sdio_runtime_scan_start())
+         return ELKWIFI_ERR_NETWORK;
+      scan_waiting = true;
+      return ELKWIFI_BUSY;
+   }
+   if (sdio_runtime_scan_busy())
+      return ELKWIFI_BUSY;
+   if (!sdio_runtime_scan_complete()) {
+      scan_waiting = false;
+      return ELKWIFI_ERR_NETWORK;
+   }
+
+   uint8_t count = sdio_runtime_scan_results(results,
+                                              SDIO_WIFI_SCAN_MAX_RESULTS);
+   response[0] = '\0';
+   for (uint8_t i = 0u; i < count; ++i) {
+      int written;
+      if (scan_fields == 7u) {
+         written = snprintf(&response[used], sizeof response - used,
+            "+CWLAP:(%u,\"%s\",%d)\r\n", (unsigned)results[i].security,
+            results[i].ssid, (int)results[i].rssi);
+      } else {
+         written = snprintf(&response[used], sizeof response - used,
+            "+CWLAP:(%u,\"%s\",%d,\"%02x:%02x:%02x:%02x:%02x:%02x\",%u)\r\n",
+            (unsigned)results[i].security, results[i].ssid, (int)results[i].rssi,
+            (unsigned)results[i].bssid[0], (unsigned)results[i].bssid[1],
+            (unsigned)results[i].bssid[2], (unsigned)results[i].bssid[3],
+            (unsigned)results[i].bssid[4], (unsigned)results[i].bssid[5],
+            (unsigned)results[i].channel);
+      }
+      if (written < 0 || (size_t)written >= sizeof response - used)
+         break;
+      used += (size_t)written;
+   }
+   if (used == 0u)
+      (void)snprintf(response, sizeof response, "OK\r\n");
+   else
+      (void)snprintf(&response[used], sizeof response - used, "\r\nOK\r\n");
+   response_string(cp, response);
+   scan_waiting = false;
+   return ELKWIFI_OK;
+}
+
+static bool command_string(uint32_t cp, const char **value)
+{
+   uint32_t limit = DISC_RAM_BASE + DISC_RAM_SIZE;
+   if (cp + 1u >= limit)
+      return false;
+   for (uint32_t pos = cp + 1u;
+        pos < limit && pos <= cp + ELKWIFI_TEXT_MAX + 1u; pos++) {
+      if (Pi1MHz->JIM_ram[pos] == 0u || Pi1MHz->JIM_ram[pos] == '\r') {
+         Pi1MHz->JIM_ram[pos] = 0u;
+         *value = (const char *)&Pi1MHz->JIM_ram[cp + 1u];
+         return true;
+      }
+   }
+   return false;
+}
+
+static void response_string(uint32_t cp, const char *value)
+{
+   size_t length = 0u;
+   while (length < ELKWIFI_TEXT_MAX && value[length] != '\0')
+      length++;
+   memcpy(&Pi1MHz->JIM_ram[cp + 1u], value, length);
+   Pi1MHz->JIM_ram[cp + 1u + length] = 0u;
+}
+
+static uint8_t process_request(uint32_t cp)
+{
+   uint8_t command = Pi1MHz->JIM_ram[cp];
+   switch (command) {
+      case ELKWIFI_CMD_STATUS:
+         /* Version discovery identifies the installed Pi service. It is not
+          * a radio-health probe and must remain available while CYW43 setup,
+          * association or DHCP is incomplete. Radio control has its own
+          * command and IFCFG/ONLINE expose the live network state. */
+         response_string(cp, ELKWIFI_VERSION_RESPONSE);
+         return ELKWIFI_OK;
+
+      case ELKWIFI_CMD_RADIO:
+         /* Public function 24 must return promptly. Start radio setup here,
+          * but do not make the caller wait for firmware or association. */
+         if (wifi_get_state() == WIFI_STATE_DISABLED && !wifi_enable_radio())
+            return ELKWIFI_ERR_NO_WIFI;
+         if (wifi_get_state() == WIFI_STATE_ERROR)
+            return ELKWIFI_ERR_NO_WIFI;
+         response_string(cp, "OK\r\n");
+         return ELKWIFI_OK;
+
+      case ELKWIFI_CMD_SCAN:
+         return wifi_scan(cp);
+
+      case ELKWIFI_CMD_JOIN:
+         return wifi_join(cp);
+
+      case ELKWIFI_CMD_IFCFG:
+         return wifi_ifcfg(cp);
+
+      case ELKWIFI_CMD_ONLINE:
+         return wifi_online(cp);
+
+      case ELKWIFI_CMD_LAPOPT:
+         if (Pi1MHz->JIM_ram[cp + 1u] != 7u
+             && Pi1MHz->JIM_ram[cp + 1u] != 127u)
+            return ELKWIFI_ERR_PARAM;
+         scan_fields = Pi1MHz->JIM_ram[cp + 1u];
+         {
+            const char *option = scan_fields == 7u ? "7\n" : "127\n";
+            uint32_t length = (uint32_t)strlen(option);
+            if (filesystemWriteFile(LAPOPT_FILE, (const uint8_t *)option,
+                                    length) != length)
+               return ELKWIFI_ERR_IO;
+         }
+         response_printf(cp, "+CWLAPOPT:%u\r\n\r\nOK\r\n",
+                         (unsigned)scan_fields);
+         return ELKWIFI_OK;
+
+      case ELKWIFI_CMD_PING:
+         return wifi_ping(cp);
+
+      case ELKWIFI_CMD_DATETIME:
+         return wifi_datetime(cp);
+
+      case ELKWIFI_CMD_CANCEL:
+         asynchronous_close();
+         response_string(cp, "OK\r\n");
+         return ELKWIFI_OK;
+
+      default:
+         return ELKWIFI_ERR_UNSUPPORTED;
+   }
+}
+
+void elkwifi_service_command(uint32_t cp, uint32_t addr, uint8_t data)
+{
+   (void)data;
+   if (Pi1MHz->JIM_ram[cp] == ELKWIFI_CMD_CANCEL) {
+      request_pointer = cp;
+      request_status_address = addr;
+      request_cancel = true;
+      Pi1MHz_MemoryWrite(addr, ELKWIFI_BUSY);
+      return;
+   }
+   if (request_pending) {
+      Pi1MHz_MemoryWrite(addr, ELKWIFI_BUSY);
+      return;
+   }
+
+   /* STATUS is version discovery, not a radio-presence test. It is a fixed
+      memory reply and can complete in the FIQ callback even while radio setup
+      is in progress or has failed. All filesystem, scan and network work
+      remains deferred below. */
+   if (Pi1MHz->JIM_ram[cp] == ELKWIFI_CMD_STATUS) {
+      response_string(cp, ELKWIFI_VERSION_RESPONSE);
+      Pi1MHz_MemoryWrite(addr, ELKWIFI_OK);
+      return;
+   }
+   request_pointer = cp;
+   request_status_address = addr;
+   request_pending = true;
+   Pi1MHz_MemoryWrite(addr, ELKWIFI_BUSY);
+}
+
+static void elkwifi_poll(void)
+{
+   uint32_t cp, addr;
+   if (request_cancel) {
+      cp = request_pointer;
+      addr = request_status_address;
+      asynchronous_close();
+      request_pending = false;
+      request_cancel = false;
+      response_string(cp, "OK\r\n");
+      Pi1MHz_MemoryWrite(addr, ELKWIFI_OK);
+      return;
+   }
+   if (!request_pending)
+      return;
+   cp = request_pointer;
+   addr = request_status_address;
+   uint8_t result = process_request(cp);
+   if (result == ELKWIFI_BUSY)
+      return;
+   request_pending = false;
+   request_cancel = false;
+   Pi1MHz_MemoryWrite(addr, result);
+}
+
+void elkwifi_service_init(uint8_t instance, uint8_t address)
+{
+   (void)instance;
+   (void)address;
+   /* Pi1MHz clears its main poll table on every BBC reset.  The services
+      registry is idempotent, so renew this claim on every init as well: this
+      recovers if a future reset path also clears the registry and avoids a
+      one-shot failure when another optional service filled the old table. */
+   if (!service_initialised) {
+      service_initialised = true;
+      lapopt_load();
+      time_utc_offset_minutes = utc_offset_parse(
+         config_get("elkwifi_utc_offset_minutes"));
+   }
+   /* Re-read the saved profile on every host reset, but credentials_load
+    * preserves an already-running association when the profile is unchanged. */
+   wifi_credentials_load();
+   (void)services_register(ELKWIFI_CMD_STATUS, ELKWIFI_CMD_LAST,
+                           elkwifi_service_command);
+   /* A host reset abandons the old OSWORD/star-command caller. Complete any
+      request latched during reset reinitialisation with a bounded error before
+      clearing it, so FCAA can never be left at BUSY. */
+   asynchronous_close();
+   unsigned int cpsr = _disable_interrupts_cspr();
+   if (request_pending || request_cancel)
+      Pi1MHz_MemoryWrite(request_status_address, ELKWIFI_ERR_NETWORK);
+   request_pending = false;
+   request_cancel = false;
+   scan_waiting = false;
+   _restore_cpsr(cpsr);
+   Pi1MHz_Register_Poll(elkwifi_poll, "elkwifi");
+}

--- a/src/elkwifi_service.h
+++ b/src/elkwifi_service.h
@@ -1,0 +1,40 @@
+#ifndef ELKWIFI_SERVICE_H
+#define ELKWIFI_SERVICE_H
+
+#include <stdint.h>
+
+/* ElkWiFi-compatible operations on the Pi1MHz &FCA6 services mailbox. */
+void elkwifi_service_init(uint8_t instance, uint8_t address);
+void elkwifi_service_command(uint32_t command_pointer, uint32_t address,
+                             uint8_t data);
+
+#define ELKWIFI_CMD_FIRST        80u
+#define ELKWIFI_CMD_STATUS       ELKWIFI_CMD_FIRST
+#define ELKWIFI_CMD_SCAN         81u
+#define ELKWIFI_CMD_JOIN         82u
+#define ELKWIFI_CMD_IFCFG        83u
+#define ELKWIFI_CMD_LAPOPT       87u
+#define ELKWIFI_CMD_PING         88u
+#define ELKWIFI_CMD_DATETIME     89u
+#define ELKWIFI_CMD_CANCEL       90u
+#define ELKWIFI_CMD_RADIO        91u
+#define ELKWIFI_CMD_ONLINE       92u
+/* 86 and 93 are deliberately left unclaimed: they carried the UEF stream and
+   guard-image commands, which are held back until a resumable inflater makes
+   the stream affordable. */
+#define ELKWIFI_CMD_LAST         ELKWIFI_CMD_ONLINE
+
+#define ELKWIFI_OK               0x00u
+#define ELKWIFI_BUSY             0x80u
+#define ELKWIFI_ERR_PARAM        0x40u
+#define ELKWIFI_ERR_IO           0x41u
+#define ELKWIFI_ERR_UNSUPPORTED  0x42u
+#define ELKWIFI_ERR_NETWORK      0x43u
+#define ELKWIFI_ERR_NO_WIFI      0x44u
+
+#define ELKWIFI_JOIN_QUERY       0u
+#define ELKWIFI_JOIN_SET         1u
+#define ELKWIFI_JOIN_LEAVE       2u
+#define ELKWIFI_JOIN_RADIO_OFF   3u
+
+#endif

--- a/src/net_service.c
+++ b/src/net_service.c
@@ -1705,8 +1705,19 @@ static void net_update_irq(void)
 
 /* ---- FIQ latch + main-loop poll ----------------------------------------- */
 
-static void net_service_command(uint32_t command_pointer, uint32_t addr,
-                                uint8_t data)
+/* Real hardware bring-up trace: last stage net_service reached, readable by
+   a NET_DEBUG host build at the fixed command page + 0xFF (beyond NET_IO_MAX,
+   so no command payload written into the command page can reach it), via the
+   same NET_COMMAND JIM address the client already selects. Harmless in a
+   non-debug build - one extra byte store. */
+static void net_debug_mark(uint8_t stage)
+{
+   uint32_t p = (DISC_RAM_BASE | 0xFF0000u | (0xF0u << 8)) + 0xFFu;
+   Pi1MHz->JIM_ram[p] = stage;
+}
+
+void net_service_command(uint32_t command_pointer, uint32_t addr,
+                         uint8_t data)
 {
    /* FIQ context: latch only.  Publish NET_BUSY (bit 7) so a Beeb that reads
       the result register before the poll runs spins rather than seeing a
@@ -1716,21 +1727,25 @@ static void net_service_command(uint32_t command_pointer, uint32_t addr,
    net_pending_data = data;
    net_pending      = true;
    Pi1MHz_MemoryWrite(addr, NET_BUSY);
+   net_debug_mark(1u);
 }
 
 static void net_service_poll(void)
 {
+   net_debug_mark(2u);
    if (net_reset_pending) {
       /* A BBC reset re-ran net_service_init.  Tear down every live pcb here,
          on the main loop - never from init/FIQ (lwIP may not be up at init,
          and is never callable from FIQ).  The table is valid (BSS), so on the
          first boot this finds only NET_ST_FREE handles and aborts nothing. */
+      net_debug_mark(3u);
       for (unsigned int i = 0; i < NET_MAX_HANDLES; i++) {
          net_pcb_release(&net_h[i], true);
          net_handle_reset(&net_h[i]);
       }
       net_irq_armed = false;         /* a reset removes any Beeb IRQ handler */
       net_reset_pending = false;
+      net_debug_mark(4u);
       /* Deliberately do NOT clear net_pending here.  A command the FIQ latches
          *during* this teardown loop would otherwise be dropped, stranding the
          NET_BUSY byte the FIQ wrote to the result register forever - the Beeb
@@ -1744,7 +1759,9 @@ static void net_service_poll(void)
       uint32_t addr = net_pending_addr;
       uint8_t  data = net_pending_data;
       net_pending = false;
+      net_debug_mark(5u);
       Pi1MHz_MemoryWrite(addr, net_dispatch(cp, data));
+      net_debug_mark(6u);
    }
 
    net_update_irq();

--- a/src/net_service.h
+++ b/src/net_service.h
@@ -66,6 +66,8 @@
 
 /* Emulator-table init: instance = nIRQ source id, address = services base. */
 void net_service_init(uint8_t instance, uint8_t address);
+void net_service_command(uint32_t command_pointer, uint32_t address,
+                         uint8_t data);
 
 /* ---- ABI constants (shared with the Beeb-side client and the tests) ----- */
 

--- a/src/secure_service.c
+++ b/src/secure_service.c
@@ -1,0 +1,143 @@
+/* Pi1MHz services-port wrapper for the NetTools secure ABI.
+ *
+ * FIQ only latches a command and publishes BUSY. All RNG, FatFs, lwIP and
+ * wolfSSH work runs from the ordinary Pi1MHz poll loop.
+ */
+#include "Pi1MHz.h"
+#include "services.h"
+#include "secure_service.h"
+#include "secure_service_core.h"
+#include "secure_service_wolfssh.h"
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#define SEC_BUSY 0x80u
+
+static volatile bool pending;
+static volatile uint32_t pending_cp;
+static volatile uint32_t pending_addr;
+static bool reset_pending;
+static nts_secure_service service;
+/* Report only capabilities which the hardware provider has reached. */
+static volatile uint8_t capability_features;
+static volatile uint8_t capability_managed_ssh;
+
+static void secure_refresh_capabilities(void)
+{
+    bool random_ready = nts_pi_wolfssh_random_ready();
+    bool ssh_ready = nts_pi_wolfssh_ready();
+    service.managed_ssh = ssh_ready;
+    capability_managed_ssh = ssh_ready ? 1u : 0u;
+    capability_features = (uint8_t)((random_ready ? 1u : 0u) |
+        (ssh_ready ? 2u : 0u) |
+        (ssh_ready && service.port != NULL &&
+         service.port->ssh_password != NULL ? 4u : 0u) |
+        (ssh_ready && service.port != NULL &&
+         service.port->sftp_open != NULL ? 8u : 0u));
+}
+
+_Static_assert(NTS_SEC_CAPS == SERVICE_CMD_SECURE_FIRST,
+               "secure service first command mismatch");
+_Static_assert(NTS_SEC_SFTP_CLOSE == SERVICE_CMD_SECURE_LAST,
+               "secure service command exceeds reserved range");
+
+static void secure_write_capabilities(uint8_t *command)
+{
+    command[1] = 1u;
+    command[2] = 1u;
+    command[3] = capability_features;
+    command[4] = 0xB8u;
+    command[5] = 0x88u;
+    command[6] = capability_managed_ssh;
+    command[7] = 1u; /* wolfSSH/wolfCrypt provider */
+    command[8] = (uint8_t)'N';
+    command[9] = (uint8_t)'T';
+    command[10] = (uint8_t)'S';
+}
+
+/* Real hardware bring-up trace: shares the net_service stage-marker byte
+   (fixed command page + 0xFF, beyond NET_IO_MAX so no command payload can
+   reach it) so an SSH capability-probe timeout, which waits via the same
+   net_dispatch/net_debug_stage path, reports which of these two services
+   last touched it. 0x8x distinguishes this service from net_service's 1-6
+   range. Harmless in a non-debug build - one extra store. */
+static void secure_debug_mark(uint8_t stage)
+{
+   uint32_t p = (DISC_RAM_BASE | 0xFF0000u | (0xF0u << 8)) + 0xFFu;
+   Pi1MHz->JIM_ram[p] = stage;
+}
+
+void secure_service_command(uint32_t command_pointer, uint32_t addr,
+                            uint8_t data)
+{
+    (void)data;
+    secure_debug_mark(0x81u);
+    /* Capability discovery is a fixed memory reply and is deliberately
+       independent of the main poll table. This also distinguishes a missing
+       command route from a stalled secure provider on physical hardware. */
+    if (Pi1MHz->JIM_ram[command_pointer] == NTS_SEC_CAPS) {
+        secure_debug_mark(0x82u);
+        secure_write_capabilities(&Pi1MHz->JIM_ram[command_pointer]);
+        secure_debug_mark(0x83u);
+        Pi1MHz_MemoryWrite(addr, NTS_OK);
+        secure_debug_mark(0x84u);
+        return;
+    }
+    secure_debug_mark(0x85u);
+    /* The 8-bit host issues mailbox operations synchronously, so there is at
+       most one live caller. Always latch the newest command, like the native
+       net service does. In particular this prevents a command arriving
+       around host-reset reinitialisation from being left behind with a BUSY
+       result after an older pending request is retired. */
+    pending_cp = command_pointer;
+    pending_addr = addr;
+    pending = true;
+    Pi1MHz_MemoryWrite(addr, SEC_BUSY);
+}
+
+static void secure_poll(void)
+{
+    if (reset_pending) {
+        nts_pi_wolfssh_reset();
+        service.port = nts_pi_wolfssh_port();
+        service.opaque = nts_pi_wolfssh_context();
+        secure_refresh_capabilities();
+        reset_pending = false;
+    }
+
+    nts_pi_wolfssh_poll();
+    secure_refresh_capabilities();
+    if (pending) {
+        uint32_t cp = pending_cp;
+        uint32_t addr = pending_addr;
+        uint8_t result;
+        if (cp < DISC_RAM_BASE) {
+            result = NTS_ERR_PARAM;
+        } else {
+            result = nts_secure_dispatch(
+                &service, &Pi1MHz->JIM_ram[cp],
+                &Pi1MHz->JIM_ram[DISC_RAM_BASE], DISC_RAM_SIZE);
+        }
+        pending = false;
+        Pi1MHz_MemoryWrite(addr, result);
+    }
+}
+
+void secure_service_init(uint8_t instance, uint8_t address)
+{
+    (void)instance;
+    (void)address;
+    /* Defer provider reset to the ordinary poll context. Do not clear a
+       pending command here: the services callback is already live and could
+       have published BUSY immediately before or during this initializer.
+       Dropping that command would strand the host forever. */
+    reset_pending = true;
+    /* The services port routes this fixed ABI range directly. Keep the
+       registry claim for compatibility and diagnostics, but never suppress
+       the poller if reset-time registry state rejects a renewal. */
+    (void)services_register(SERVICE_CMD_SECURE_FIRST,
+                            SERVICE_CMD_SECURE_LAST,
+                            secure_service_command);
+    Pi1MHz_Register_Poll(secure_poll, "secure");
+}

--- a/src/secure_service.h
+++ b/src/secure_service.h
@@ -1,0 +1,10 @@
+#ifndef PI1MHZ_SECURE_SERVICE_H
+#define PI1MHZ_SECURE_SERVICE_H
+
+#include <stdint.h>
+
+void secure_service_init(uint8_t instance, uint8_t address);
+void secure_service_command(uint32_t command_pointer, uint32_t address,
+                            uint8_t data);
+
+#endif

--- a/src/secure_service_core.c
+++ b/src/secure_service_core.c
@@ -1,0 +1,245 @@
+#include "secure_service_core.h"
+
+#include <string.h>
+
+#define NTS_FINGERPRINT_ADDRESS 0x020500u
+
+static uint16_t rd16(const uint8_t *p)
+{
+    return (uint16_t)p[0] | (uint16_t)((uint16_t)p[1] << 8);
+}
+
+static uint32_t rd32(const uint8_t *p)
+{
+    return (uint32_t)p[0] | ((uint32_t)p[1] << 8) |
+           ((uint32_t)p[2] << 16) | ((uint32_t)p[3] << 24);
+}
+
+static void wr24(uint8_t *p, uint32_t value)
+{
+    p[0] = (uint8_t)value;
+    p[1] = (uint8_t)(value >> 8);
+    p[2] = (uint8_t)(value >> 16);
+}
+
+static int buffer_ok(uint32_t address, uint32_t length, size_t size)
+{
+    return address < size && length <= size - address;
+}
+
+static const char *jim_string(uint8_t *jim, size_t size, uint32_t address)
+{
+    if (address >= size || memchr(jim + address, 0, size - address) == NULL)
+        return NULL;
+    return (const char *)jim + address;
+}
+
+static size_t bounded_length(const char *text, size_t maximum)
+{
+    size_t length = 0;
+    while (length < maximum && text[length] != '\0') length++;
+    return length;
+}
+
+static void wipe_bytes(uint8_t *data, size_t length)
+{
+    volatile uint8_t *p = data;
+    while (length-- != 0u) *p++ = 0;
+}
+
+uint8_t nts_secure_dispatch(nts_secure_service *service, uint8_t *command,
+                            uint8_t *jim, size_t jim_size)
+{
+    uint32_t address;
+    uint32_t length;
+    int result;
+
+    if (service == NULL || service->port == NULL || command == NULL ||
+        jim == NULL)
+        return NTS_ERR_PARAM;
+
+    switch (command[0]) {
+    case NTS_SEC_CAPS:
+        command[1] = 1;
+        command[2] = 1;
+        command[3] = (uint8_t)(1u | (service->managed_ssh ? 2u : 0u));
+        if (service->managed_ssh && service->port->ssh_password != NULL)
+            command[3] |= 4u;
+        if (service->managed_ssh && service->port->sftp_open != NULL)
+            command[3] |= 8u;
+        command[4] = 0xB8;
+        command[5] = 0x88;
+        command[6] = service->managed_ssh ? 1 : 0;
+        command[7] = 1; /* wolfSSH/wolfCrypt provider */
+        memcpy(command + 8, "NTS", 3);
+        return NTS_OK;
+
+    case NTS_SEC_RANDOM:
+        length = rd16(command + 1);
+        address = rd32(command + 4);
+        if (length == 0 || length > 64 || !buffer_ok(address, length, jim_size))
+            return NTS_ERR_PARAM;
+        if (service->port->random == NULL ||
+            service->port->random(service->opaque, jim + address, length) != 0)
+            return NTS_ERR_UNSUPPORTED;
+        return NTS_OK;
+
+    case NTS_SEC_SSH_OPEN: {
+        const char *url = jim_string(jim, jim_size, rd32(command + 2));
+        const char *username = jim_string(jim, jim_size, rd32(command + 6));
+        char fingerprint[96] = { 0 };
+        if (!service->managed_ssh || service->port->ssh_open == NULL)
+            return NTS_ERR_UNSUPPORTED;
+        if (url == NULL || username == NULL || *username == '\0')
+            return NTS_ERR_PARAM;
+        result = service->port->ssh_open(service->opaque, url, username,
+                                         (command[1] & 1u) != 0,
+                                         fingerprint);
+        if (result == NTS_HOSTKEY_UNKNOWN) {
+            size_t count = bounded_length(fingerprint, sizeof(fingerprint));
+            if (count == sizeof(fingerprint) ||
+                !buffer_ok(NTS_FINGERPRINT_ADDRESS, (uint32_t)count + 1u,
+                           jim_size))
+                return NTS_ERR_PARAM;
+            memcpy(jim + NTS_FINGERPRINT_ADDRESS, fingerprint, count + 1u);
+        }
+        return (uint8_t)result;
+    }
+
+    case NTS_SEC_SSH_READ:
+        length = (uint32_t)command[1] | ((uint32_t)command[2] << 8) |
+                 ((uint32_t)command[3] << 16);
+        address = rd32(command + 4);
+        if (service->port->ssh_read == NULL ||
+            !buffer_ok(address, length, jim_size))
+            return NTS_ERR_PARAM;
+        result = service->port->ssh_read(service->opaque, jim + address,
+                                         length);
+        if (result < 0)
+            return (uint8_t)-result;
+        wr24(command + 1, (uint32_t)result);
+        return NTS_OK;
+
+    case NTS_SEC_SSH_WRITE:
+        length = (uint32_t)command[1] | ((uint32_t)command[2] << 8) |
+                 ((uint32_t)command[3] << 16);
+        address = rd32(command + 4);
+        if (service->port->ssh_write == NULL ||
+            !buffer_ok(address, length, jim_size))
+            return NTS_ERR_PARAM;
+        result = service->port->ssh_write(service->opaque, jim + address,
+                                          length);
+        if (result < 0)
+            return (uint8_t)-result;
+        wr24(command + 1, (uint32_t)result);
+        return NTS_OK;
+
+    case NTS_SEC_SSH_CLOSE:
+        if (service->port->ssh_close != NULL)
+            service->port->ssh_close(service->opaque);
+        return NTS_OK;
+
+    case NTS_SEC_SSH_PASSWORD:
+        length = command[1];
+        address = rd32(command + 4);
+        if (!service->managed_ssh || service->port->ssh_password == NULL ||
+            length == 0u || length > 127u ||
+            !buffer_ok(address, length, jim_size))
+            return NTS_ERR_PARAM;
+        result = service->port->ssh_password(service->opaque,
+                                             jim + address, length);
+        wipe_bytes(jim + address, length);
+        return result == 0 ? NTS_OK : NTS_ERR_PARAM;
+
+    case NTS_SEC_SFTP_OPEN: {
+        const char *url = jim_string(jim, jim_size, rd32(command + 2));
+        const char *username = jim_string(jim, jim_size, rd32(command + 6));
+        char fingerprint[96] = { 0 };
+        if (!service->managed_ssh || service->port->sftp_open == NULL)
+            return NTS_ERR_UNSUPPORTED;
+        if (url == NULL || username == NULL || *username == '\0')
+            return NTS_ERR_PARAM;
+        result = service->port->sftp_open(service->opaque, url, username,
+                                          (command[1] & 1u) != 0,
+                                          fingerprint);
+        if (result == NTS_HOSTKEY_UNKNOWN) {
+            size_t count = bounded_length(fingerprint, sizeof(fingerprint));
+            if (count == sizeof(fingerprint) ||
+                !buffer_ok(NTS_FINGERPRINT_ADDRESS, (uint32_t)count + 1u,
+                           jim_size))
+                return NTS_ERR_PARAM;
+            memcpy(jim + NTS_FINGERPRINT_ADDRESS, fingerprint, count + 1u);
+        }
+        return (uint8_t)result;
+    }
+
+    case NTS_SEC_SFTP_PWD:
+    case NTS_SEC_SFTP_CD:
+    case NTS_SEC_SFTP_LS:
+    case NTS_SEC_SFTP_DELETE:
+    case NTS_SEC_SFTP_MKDIR:
+    case NTS_SEC_SFTP_RMDIR: {
+        const char *path = jim_string(jim, jim_size, rd32(command + 4));
+        uint32_t output = rd32(command + 8);
+        length = (uint32_t)command[1] | ((uint32_t)command[2] << 8) |
+                 ((uint32_t)command[3] << 16);
+        if (service->port->sftp_path == NULL || path == NULL ||
+            !buffer_ok(output, length, jim_size))
+            return NTS_ERR_PARAM;
+        result = service->port->sftp_path(service->opaque, command[0], path,
+                                          jim + output, length);
+        if (result < 0) return (uint8_t)-result;
+        if ((uint32_t)result > length) return NTS_ERR_PROTOCOL;
+        wr24(command + 1, (uint32_t)result);
+        return NTS_OK;
+    }
+
+    case NTS_SEC_SFTP_GET_OPEN:
+    case NTS_SEC_SFTP_PUT_OPEN: {
+        const char *path = jim_string(jim, jim_size, rd32(command + 4));
+        if (path == NULL || *path == '\0') return NTS_ERR_PARAM;
+        if (command[0] == NTS_SEC_SFTP_GET_OPEN) {
+            if (service->port->sftp_get_open == NULL) return NTS_ERR_UNSUPPORTED;
+            result = service->port->sftp_get_open(service->opaque, path);
+        } else {
+            if (service->port->sftp_put_open == NULL) return NTS_ERR_UNSUPPORTED;
+            result = service->port->sftp_put_open(service->opaque, path);
+        }
+        return result < 0 ? (uint8_t)-result : NTS_OK;
+    }
+
+    case NTS_SEC_SFTP_GET_READ:
+    case NTS_SEC_SFTP_PUT_WRITE:
+        length = (uint32_t)command[1] | ((uint32_t)command[2] << 8) |
+                 ((uint32_t)command[3] << 16);
+        address = rd32(command + 4);
+        if (!buffer_ok(address, length, jim_size)) return NTS_ERR_PARAM;
+        if (command[0] == NTS_SEC_SFTP_GET_READ) {
+            if (service->port->sftp_get_read == NULL) return NTS_ERR_UNSUPPORTED;
+            result = service->port->sftp_get_read(service->opaque,
+                                                   jim + address, length);
+        } else {
+            if (service->port->sftp_put_write == NULL) return NTS_ERR_UNSUPPORTED;
+            result = service->port->sftp_put_write(service->opaque,
+                                                    jim + address, length);
+        }
+        if (result < 0) return (uint8_t)-result;
+        if ((uint32_t)result > length) return NTS_ERR_PROTOCOL;
+        wr24(command + 1, (uint32_t)result);
+        return NTS_OK;
+
+    case NTS_SEC_SFTP_TRANSFER_CLOSE:
+        if (service->port->sftp_transfer_close == NULL)
+            return NTS_ERR_UNSUPPORTED;
+        result = service->port->sftp_transfer_close(service->opaque);
+        return result < 0 ? (uint8_t)-result : NTS_OK;
+
+    case NTS_SEC_SFTP_CLOSE:
+        if (service->port->sftp_close != NULL)
+            service->port->sftp_close(service->opaque);
+        return NTS_OK;
+
+    default:
+        return NTS_ERR_UNSUPPORTED;
+    }
+}

--- a/src/secure_service_core.h
+++ b/src/secure_service_core.h
@@ -1,0 +1,67 @@
+#ifndef NETTOOLS_SECURE_SERVICE_CORE_H
+#define NETTOOLS_SECURE_SERVICE_CORE_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+enum {
+    NTS_SEC_CAPS = 94,
+    NTS_SEC_RANDOM = 95,
+    NTS_SEC_SSH_OPEN = 96,
+    NTS_SEC_SSH_READ = 97,
+    NTS_SEC_SSH_WRITE = 98,
+    NTS_SEC_SSH_CLOSE = 99,
+    NTS_SEC_SSH_PASSWORD = 100,
+    NTS_SEC_SFTP_OPEN = 101,
+    NTS_SEC_SFTP_PWD = 102,
+    NTS_SEC_SFTP_CD = 103,
+    NTS_SEC_SFTP_LS = 104,
+    NTS_SEC_SFTP_DELETE = 105,
+    NTS_SEC_SFTP_MKDIR = 106,
+    NTS_SEC_SFTP_RMDIR = 107,
+    NTS_SEC_SFTP_GET_OPEN = 108,
+    NTS_SEC_SFTP_GET_READ = 109,
+    NTS_SEC_SFTP_PUT_OPEN = 110,
+    NTS_SEC_SFTP_PUT_WRITE = 111,
+    NTS_SEC_SFTP_TRANSFER_CLOSE = 112,
+    NTS_SEC_SFTP_CLOSE = 113,
+    NTS_OK = 0,
+    NTS_PENDING = 1,
+    NTS_EOF = 0x20,
+    NTS_ERR_PARAM = 0x23,
+    NTS_ERR_UNSUPPORTED = 0x27,
+    NTS_ERR_PROTOCOL = 0x2B,
+    NTS_HOSTKEY_UNKNOWN = 0x2C,
+    NTS_AUTH_FAILED = 0x2D
+};
+
+typedef struct nts_secure_port {
+    int (*random)(void *opaque, uint8_t *out, size_t length);
+    uint8_t (*ssh_open)(void *opaque, const char *url, const char *username,
+                        int trust_unknown, char fingerprint[96]);
+    int (*ssh_read)(void *opaque, uint8_t *out, size_t maximum);
+    int (*ssh_write)(void *opaque, const uint8_t *data, size_t length);
+    int (*ssh_password)(void *opaque, const uint8_t *password, size_t length);
+    void (*ssh_close)(void *opaque);
+    uint8_t (*sftp_open)(void *opaque, const char *url, const char *username,
+                         int trust_unknown, char fingerprint[96]);
+    int (*sftp_path)(void *opaque, uint8_t operation, const char *path,
+                     uint8_t *out, size_t maximum);
+    int (*sftp_get_open)(void *opaque, const char *path);
+    int (*sftp_get_read)(void *opaque, uint8_t *out, size_t maximum);
+    int (*sftp_put_open)(void *opaque, const char *path);
+    int (*sftp_put_write)(void *opaque, const uint8_t *data, size_t length);
+    int (*sftp_transfer_close)(void *opaque);
+    void (*sftp_close)(void *opaque);
+} nts_secure_port;
+
+typedef struct nts_secure_service {
+    const nts_secure_port *port;
+    void *opaque;
+    int managed_ssh;
+} nts_secure_service;
+
+uint8_t nts_secure_dispatch(nts_secure_service *service, uint8_t *command,
+                            uint8_t *jim, size_t jim_size);
+
+#endif

--- a/src/secure_service_wolfssh.c
+++ b/src/secure_service_wolfssh.c
@@ -1,0 +1,959 @@
+/* Bare-metal Pi1MHz wolfSSH provider.
+ *
+ * This file is copied into the Pi1MHz source tree by install.sh.  It keeps
+ * every lwIP, FatFs and crypto operation in the normal poll context; the FIQ
+ * wrapper in secure_service.c only latches command bytes.
+ */
+#include "secure_service_wolfssh.h"
+
+#include "BeebSCSI/fatfs/ff.h"
+#include "rpi/base.h"
+#include "rpi/systimer.h"
+#include "wifi/wifi_lwip.h"
+#include "lwip/altcp.h"
+#include "lwip/dns.h"
+#include "lwip/err.h"
+#include "lwip/ip_addr.h"
+#include "lwip/pbuf.h"
+#include "lwip/tcp.h"
+
+#include <wolfssh/error.h>
+#include <wolfssh/ssh.h>
+#include <wolfssh/wolfsftp.h>
+#include <wolfssl/wolfcrypt/coding.h>
+#include <wolfssl/wolfcrypt/sha256.h>
+
+#include <stdbool.h>
+#include <limits.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define SSH_RX_SIZE 16384u
+#define SSH_FILE_SIZE 4096u
+#define SSH_DIR "Pi1MHz/ssh"
+#define SSH_PRIVATE SSH_DIR "/id_ed25519"
+#define SSH_PUBLIC SSH_DIR "/id_ed25519.pub"
+#define SSH_HOSTS SSH_DIR "/known_hosts"
+#define SSH_HOSTS_TMP SSH_DIR "/known_hosts.tmp"
+#define SSH_HOSTS_BAK SSH_DIR "/known_hosts.bak"
+
+#define NTS_ERR_DNS 0x24u
+#define NTS_ERR_INUSE 0x21u
+#define NTS_ERR_CONN 0x25u
+#define NTS_ERR_PROTOCOL 0x2Bu
+
+#define BCM_RNG_BASE (PERIPHERAL_BASE + 0x104000u)
+#define BCM_RNG_CTRL (*(volatile uint32_t *)(BCM_RNG_BASE + 0x00u))
+#define BCM_RNG_STATUS (*(volatile uint32_t *)(BCM_RNG_BASE + 0x04u))
+#define BCM_RNG_DATA (*(volatile uint32_t *)(BCM_RNG_BASE + 0x08u))
+#define BCM_RNG_INT_MASK (*(volatile uint32_t *)(BCM_RNG_BASE + 0x10u))
+
+typedef enum {
+    SSH_IDLE, SSH_RESOLVING, SSH_CONNECTING, SSH_HANDSHAKE, SSH_RESIZE,
+    SSH_UP, SSH_FAILED
+} ssh_stage;
+
+typedef struct {
+    ssh_stage stage;
+    struct altcp_pcb *pcb;
+    ip_addr_t address;
+    bool dns_done;
+    bool dns_ok;
+    bool eof;
+    bool transport_error;
+    bool trust_unknown;
+    bool host_unknown;
+    bool host_changed;
+    uint16_t port;
+    uint16_t rx_head;
+    uint16_t rx_tail;
+    uint16_t rx_count;
+    char host[192];
+    char host_id[224];
+    char username[64];
+    char fingerprint[96];
+    char host_key_type[64];
+    char host_key[2048];
+    WOLFSSH_CTX *wolf_ctx;
+    WOLFSSH *ssh;
+    byte *public_key;
+    word32 public_key_size;
+    const byte *public_key_type;
+    word32 public_key_type_size;
+    byte *private_key;
+    word32 private_key_size;
+    const byte *private_key_type;
+    word32 private_key_type_size;
+    byte password[128];
+    word32 password_size;
+    bool sftp_mode;
+    byte sftp_handle[WOLFSSH_MAX_HANDLE];
+    word32 sftp_handle_size;
+    word32 sftp_offset[2];
+    uint8_t sftp_transfer; /* 0 none, 1 download, 2 upload */
+    char sftp_cwd[256];
+} pi_ssh;
+
+static pi_ssh client;
+static uint8_t rx_ring[SSH_RX_SIZE];
+static uint8_t file_buffer[SSH_FILE_SIZE + 1u];
+static bool provider_ready;
+static bool wolfssh_started;
+static bool wolfssh_init_attempted;
+static bool rng_started;
+static bool rng_ready;
+static bool rng_have_last;
+static uint32_t rng_last;
+static uint8_t rng_sample_count;
+static uint8_t rng_zero_count;
+static uint8_t rng_ones_count;
+
+/* Warm-up is not waited for here. rng_begin discards 0x40000 oscillator bits
+   and rng_poll samples the result from the cooperative poll loop, so by the
+   time a caller reaches this the generator is running at its hardware rate and
+   a word is due in microseconds. The bound is a safety net against a generator
+   that stops, not a settling time: at 750ms it was long enough to stall the
+   1MHz bus service for most of a second. */
+#define RNG_WORD_DEADLINE_US 5000u
+
+static int rng_word(uint32_t *out)
+{
+    uint32_t started_us = RPI_GetSystemTime();
+    while ((BCM_RNG_STATUS >> 24) == 0u) {
+        if (RPI_GetSystemTime() - started_us >= RNG_WORD_DEADLINE_US) return -1;
+        RPI_WaitMicroSeconds(1u);
+    }
+    *out = BCM_RNG_DATA;
+    if (rng_have_last && *out == rng_last) return -1;
+    rng_last = *out;
+    rng_have_last = true;
+    return 0;
+}
+
+/* Named by CUSTOM_RAND_GENERATE_BLOCK in user_settings.h. */
+int nts_bcm_random_block(unsigned char *out, unsigned int length)
+{
+    uint32_t word = 0;
+    unsigned int available = 0;
+    /* Fail fast rather than block. The settling wait belongs to rng_poll, and
+       a caller which arrives before the generator is ready must retry: the
+       capability byte reports readiness so the host can wait for it rather
+       than have the Pi stall inside a command. */
+    if (!rng_started || !rng_ready || out == NULL) return -1;
+    while (length != 0u) {
+        if (available == 0u) {
+            if (rng_word(&word) != 0) return -1;
+            available = 4u;
+        }
+        *out++ = (uint8_t)word;
+        word >>= 8;
+        available--;
+        length--;
+    }
+    return 0;
+}
+
+static void rng_begin(void)
+{
+    BCM_RNG_INT_MASK |= 1u;
+    BCM_RNG_STATUS = 0x00040000u; /* discard the first 0x40000 oscillator bits */
+    BCM_RNG_CTRL |= 1u;
+    rng_started = true;
+    rng_ready = false;
+    rng_have_last = false;
+    rng_sample_count = 0u;
+    rng_zero_count = 0u;
+    rng_ones_count = 0u;
+}
+
+static void rng_poll(void)
+{
+    uint32_t word;
+    if (!rng_started || rng_ready || (BCM_RNG_STATUS >> 24) == 0u) return;
+
+    word = BCM_RNG_DATA;
+    if (rng_have_last && word == rng_last) {
+        rng_started = false;
+        return;
+    }
+    rng_last = word;
+    rng_have_last = true;
+    for (unsigned int i = 0; i < 4u; i++) {
+        uint8_t value = (uint8_t)word;
+        if (value == 0u) rng_zero_count++;
+        if (value == 0xffu) rng_ones_count++;
+        word >>= 8;
+    }
+    rng_sample_count++;
+    if (rng_sample_count == 8u) {
+        rng_ready = rng_zero_count != 32u && rng_ones_count != 32u;
+        if (!rng_ready) rng_started = false;
+    }
+}
+
+static int port_random(void *opaque, uint8_t *out, size_t length)
+{
+    (void)opaque;
+    if (length > UINT32_MAX) return -1;
+    return nts_bcm_random_block(out, (unsigned int)length);
+}
+
+static int read_file(const char *path, uint8_t *buffer, size_t maximum,
+                     size_t *length)
+{
+    FIL file;
+    UINT got = 0;
+    FSIZE_t size;
+    if (f_open(&file, path, FA_READ) != FR_OK) return -1;
+    size = f_size(&file);
+    if (size > maximum || f_read(&file, buffer, (UINT)size, &got) != FR_OK ||
+        got != (UINT)size) {
+        (void)f_close(&file);
+        return -1;
+    }
+    (void)f_close(&file);
+    *length = got;
+    return 0;
+}
+
+static int write_file(const char *path, const uint8_t *data, size_t length)
+{
+    FIL file;
+    UINT wrote = 0;
+    if (length > UINT_MAX ||
+        f_open(&file, path, FA_CREATE_ALWAYS | FA_WRITE) != FR_OK) return -1;
+    if (f_write(&file, data, (UINT)length, &wrote) != FR_OK ||
+        wrote != (UINT)length || f_sync(&file) != FR_OK) {
+        (void)f_close(&file);
+        return -1;
+    }
+    return f_close(&file) == FR_OK ? 0 : -1;
+}
+
+static void free_keys(void)
+{
+    if (client.private_key != NULL) {
+        memset(client.private_key, 0, client.private_key_size);
+        free(client.private_key);
+    }
+    free(client.public_key);
+    client.private_key = NULL;
+    client.public_key = NULL;
+    client.private_key_size = client.public_key_size = 0;
+}
+
+static int load_keys(void)
+{
+    size_t length;
+    int result;
+    if (read_file(SSH_PRIVATE, file_buffer, SSH_FILE_SIZE, &length) != 0)
+        return -1;
+    result = wolfSSH_ReadKey_buffer(file_buffer, (word32)length,
+        WOLFSSH_FORMAT_OPENSSH, &client.private_key, &client.private_key_size,
+        &client.private_key_type, &client.private_key_type_size, NULL);
+    memset(file_buffer, 0, length);
+    if (result != WS_SUCCESS) return -1;
+    if (read_file(SSH_PUBLIC, file_buffer, SSH_FILE_SIZE, &length) != 0)
+        return -1;
+    result = wolfSSH_ReadKey_buffer(file_buffer, (word32)length,
+        WOLFSSH_FORMAT_SSH, &client.public_key, &client.public_key_size,
+        &client.public_key_type, &client.public_key_type_size, NULL);
+    memset(file_buffer, 0, length);
+    return result == WS_SUCCESS ? 0 : -1;
+}
+
+static int auth_callback(byte type, WS_UserAuthData *data, void *opaque)
+{
+    pi_ssh *state = opaque;
+    WS_UserAuthData_PublicKey *key;
+    if (type == WOLFSSH_USERAUTH_PASSWORD && state->password_size != 0u) {
+        data->sf.password.password = state->password;
+        data->sf.password.passwordSz = state->password_size;
+        return WOLFSSH_USERAUTH_SUCCESS;
+    }
+    if (type != WOLFSSH_USERAUTH_PUBLICKEY || state->public_key == NULL ||
+        state->private_key == NULL) return WOLFSSH_USERAUTH_FAILURE;
+    key = &data->sf.publicKey;
+    key->publicKeyType = state->public_key_type;
+    key->publicKeyTypeSz = state->public_key_type_size;
+    key->publicKey = state->public_key;
+    key->publicKeySz = state->public_key_size;
+    key->privateKey = state->private_key;
+    key->privateKeySz = state->private_key_size;
+    return WOLFSSH_USERAUTH_SUCCESS;
+}
+
+static int find_known_host(void)
+{
+    FILINFO info;
+    size_t length;
+    char *line;
+    FRESULT stat_result = f_stat(SSH_HOSTS, &info);
+    if (stat_result == FR_NO_FILE || stat_result == FR_NO_PATH) return 0;
+    if (stat_result != FR_OK ||
+        read_file(SSH_HOSTS, file_buffer, SSH_FILE_SIZE, &length) != 0)
+        return -1;
+    file_buffer[length] = 0;
+    line = (char *)file_buffer;
+    while (*line != '\0') {
+        char *end = strchr(line, '\n');
+        char *space = strchr(line, ' ');
+        char *key_space;
+        if (end == NULL) end = line + strlen(line);
+        key_space = space != NULL ? strchr(space + 1, ' ') : NULL;
+        if (space != NULL && key_space != NULL && key_space < end &&
+            (size_t)(space - line) == strlen(client.host_id) &&
+            memcmp(line, client.host_id, (size_t)(space - line)) == 0) {
+            size_t type_len = (size_t)(key_space - space - 1);
+            size_t key_len = (size_t)(end - key_space - 1);
+            int result = type_len == strlen(client.host_key_type) &&
+                key_len == strlen(client.host_key) &&
+                memcmp(space + 1, client.host_key_type, type_len) == 0 &&
+                memcmp(key_space + 1, client.host_key, key_len) == 0 ? 1 : -1;
+            memset(file_buffer, 0, length + 1u);
+            return result;
+        }
+        line = *end == '\0' ? end : end + 1;
+    }
+    memset(file_buffer, 0, length + 1u);
+    return 0;
+}
+
+static int persist_known_host(void)
+{
+    FILINFO info;
+    size_t length = 0;
+    int count;
+    bool had_old = f_stat(SSH_HOSTS, &info) == FR_OK;
+    if (had_old && read_file(SSH_HOSTS, file_buffer, SSH_FILE_SIZE, &length) != 0)
+        return -1;
+    count = snprintf((char *)file_buffer + length, sizeof(file_buffer) - length,
+                     "%s %s %s\n", client.host_id, client.host_key_type,
+                     client.host_key);
+    if (count <= 0 || (size_t)count >= sizeof(file_buffer) - length) return -1;
+    if (write_file(SSH_HOSTS_TMP, file_buffer, length + (size_t)count) != 0)
+        return -1;
+    memset(file_buffer, 0, length + (size_t)count);
+    (void)f_unlink(SSH_HOSTS_BAK);
+    if (had_old && f_rename(SSH_HOSTS, SSH_HOSTS_BAK) != FR_OK) goto fail;
+    if (f_rename(SSH_HOSTS_TMP, SSH_HOSTS) != FR_OK) {
+        if (had_old) (void)f_rename(SSH_HOSTS_BAK, SSH_HOSTS);
+        goto fail;
+    }
+    if (had_old) (void)f_unlink(SSH_HOSTS_BAK);
+    return 0;
+fail:
+    (void)f_unlink(SSH_HOSTS_TMP);
+    return -1;
+}
+
+static int hostkey_callback(const byte *key, word32 key_size, void *opaque)
+{
+    pi_ssh *state = opaque;
+    wc_Sha256 sha;
+    byte digest[WC_SHA256_DIGEST_SIZE];
+    byte encoded[64];
+    word32 encoded_size = sizeof(encoded);
+    word32 host_key_size = sizeof(state->host_key) - 1u;
+    word32 name_size;
+    int known;
+    int hash_result;
+    if (key_size < 4u) return -1;
+    name_size = ((word32)key[0] << 24) | ((word32)key[1] << 16) |
+                ((word32)key[2] << 8) | key[3];
+    if (name_size == 0u || name_size >= sizeof(state->host_key_type) ||
+        name_size > key_size - 4u ||
+        Base64_Encode_NoNl(key, key_size, (byte *)state->host_key,
+                           &host_key_size) != 0) return -1;
+    state->host_key[host_key_size] = '\0';
+    memcpy(state->host_key_type, key + 4u, name_size);
+    state->host_key_type[name_size] = '\0';
+    hash_result = wc_InitSha256(&sha);
+    if (hash_result == 0) hash_result = wc_Sha256Update(&sha, key, key_size);
+    if (hash_result == 0) hash_result = wc_Sha256Final(&sha, digest);
+    wc_Sha256Free(&sha);
+    if (hash_result != 0 || Base64_Encode_NoNl(digest, sizeof(digest),
+                                               encoded, &encoded_size) != 0)
+        return -1;
+    while (encoded_size != 0u && encoded[encoded_size - 1u] == '=')
+        encoded_size--;
+    if (encoded_size + 8u >= sizeof(state->fingerprint)) return -1;
+    memcpy(state->fingerprint, "SHA256:", 7u);
+    memcpy(state->fingerprint + 7u, encoded, encoded_size);
+    state->fingerprint[7u + encoded_size] = '\0';
+    known = find_known_host();
+    if (known > 0) return 0;
+    if (known < 0) { state->host_changed = true; return -1; }
+    if (!state->trust_unknown) { state->host_unknown = true; return -1; }
+    return persist_known_host();
+}
+
+static uint16_t ring_free(void) { return (uint16_t)(SSH_RX_SIZE - client.rx_count); }
+
+static err_t nts_tcp_recv(void *arg, struct altcp_pcb *pcb, struct pbuf *p,
+                          err_t error)
+{
+    pi_ssh *state = arg;
+    if (state == NULL) { if (p != NULL) pbuf_free(p); return ERR_OK; }
+    if (error != ERR_OK) {
+        if (p != NULL) pbuf_free(p);
+        state->transport_error = true;
+        return ERR_OK;
+    }
+    if (p == NULL) { state->eof = true; return ERR_OK; }
+    if (p->tot_len > ring_free()) return ERR_MEM;
+    for (struct pbuf *q = p; q != NULL; q = q->next) {
+        const uint8_t *source = q->payload;
+        for (uint16_t i = 0; i < q->len; i++) {
+            rx_ring[state->rx_head] = source[i];
+            state->rx_head = (uint16_t)((state->rx_head + 1u) &
+                                        (SSH_RX_SIZE - 1u));
+        }
+        state->rx_count = (uint16_t)(state->rx_count + q->len);
+    }
+    altcp_recved(pcb, p->tot_len);
+    pbuf_free(p);
+    return ERR_OK;
+}
+
+static err_t nts_tcp_connected(void *arg, struct altcp_pcb *pcb, err_t error)
+{
+    pi_ssh *state = arg;
+    (void)pcb;
+    if (state != NULL)
+        state->stage = error == ERR_OK ? SSH_HANDSHAKE : SSH_FAILED;
+    return ERR_OK;
+}
+
+static void nts_tcp_error(void *arg, err_t error)
+{
+    pi_ssh *state = arg;
+    (void)error;
+    if (state != NULL) {
+        state->pcb = NULL;
+        state->transport_error = true;
+        state->stage = SSH_FAILED;
+    }
+}
+
+static int io_recv(WOLFSSH *ssh, void *out, word32 size, void *opaque)
+{
+    pi_ssh *state = opaque;
+    uint8_t *destination = out;
+    word32 count = size < state->rx_count ? size : state->rx_count;
+    (void)ssh;
+    for (word32 i = 0; i < count; i++) {
+        destination[i] = rx_ring[state->rx_tail];
+        state->rx_tail = (uint16_t)((state->rx_tail + 1u) &
+                                    (SSH_RX_SIZE - 1u));
+    }
+    state->rx_count = (uint16_t)(state->rx_count - count);
+    if (count != 0u) return (int)count;
+    if (state->transport_error) return WS_CBIO_ERR_CONN_RST;
+    if (state->eof) return WS_CBIO_ERR_CONN_CLOSE;
+    return WS_CBIO_ERR_WANT_READ;
+}
+
+static int io_send(WOLFSSH *ssh, void *data, word32 size, void *opaque)
+{
+    pi_ssh *state = opaque;
+    u16_t available;
+    word32 count;
+    err_t result;
+    (void)ssh;
+    if (state->pcb == NULL || state->transport_error)
+        return WS_CBIO_ERR_CONN_RST;
+    available = altcp_sndbuf(state->pcb);
+    count = size < available ? size : available;
+    if (count == 0u) return WS_CBIO_ERR_WANT_WRITE;
+    result = altcp_write(state->pcb, data, (u16_t)count, TCP_WRITE_FLAG_COPY);
+    if (result == ERR_MEM) return WS_CBIO_ERR_WANT_WRITE;
+    if (result != ERR_OK) return WS_CBIO_ERR_CONN_RST;
+    (void)altcp_output(state->pcb);
+    wifi_lwip_rx_kick();
+    return (int)count;
+}
+
+static void dns_found(const char *name, const ip_addr_t *address, void *opaque)
+{
+    pi_ssh *state = opaque;
+    (void)name;
+    if (state == NULL) return;
+    state->dns_done = true;
+    state->dns_ok = address != NULL;
+    if (address != NULL) state->address = *address;
+}
+
+static int parse_url(const char *url)
+{
+    const char *start, *end, *colon;
+    size_t length;
+    unsigned long port = 0;
+    if (strncmp(url, "TCP://", 6u) != 0) return -1;
+    start = url + 6u;
+    end = strchr(start, '/');
+    if (end == NULL) end = start + strlen(start);
+    colon = end;
+    while (colon > start && colon[-1] != ':') colon--;
+    if (colon == start) return -1;
+    length = (size_t)(colon - start - 1);
+    if (length == 0u || length >= sizeof(client.host)) return -1;
+    memcpy(client.host, start, length); client.host[length] = '\0';
+    for (const char *p = colon; p < end; p++) {
+        if (*p < '0' || *p > '9') return -1;
+        port = port * 10u + (unsigned long)(*p - '0');
+        if (port > 65535u) return -1;
+    }
+    if (port == 0u) return -1;
+    client.port = (uint16_t)port;
+    if (port == 22u) {
+        if (length >= sizeof(client.host_id)) return -1;
+        memcpy(client.host_id, client.host, length + 1u);
+    } else {
+        int count = snprintf(client.host_id, sizeof(client.host_id),
+                             "[%s]:%u", client.host, (unsigned)client.port);
+        if (count <= 0 || (size_t)count >= sizeof(client.host_id)) return -1;
+    }
+    return 0;
+}
+
+static bool want_io(int result)
+{
+    int error = client.ssh != NULL ? wolfSSH_get_error(client.ssh) : result;
+    return result == WS_WANT_READ || result == WS_WANT_WRITE ||
+           error == WS_WANT_READ || error == WS_WANT_WRITE;
+}
+
+static bool channel_finished(int result)
+{
+    int error = client.ssh != NULL ? wolfSSH_get_error(client.ssh) : result;
+    return result == WS_EOF || result == WS_CHANNEL_CLOSED ||
+           error == WS_EOF || error == WS_CHANNEL_CLOSED;
+}
+
+static void clear_password(void)
+{
+    volatile byte *p = client.password;
+    size_t count = sizeof(client.password);
+    while (count-- != 0u) *p++ = 0;
+    client.password_size = 0;
+}
+
+static void close_connection(bool keep_password)
+{
+    byte saved_password[128];
+    word32 saved_size = 0;
+    if (keep_password && client.password_size != 0u) {
+        saved_size = client.password_size;
+        memcpy(saved_password, client.password, saved_size);
+    }
+    if (client.ssh != NULL) {
+        if (client.stage == SSH_UP) (void)wolfSSH_shutdown(client.ssh);
+        wolfSSH_free(client.ssh);
+    }
+    if (client.wolf_ctx != NULL) wolfSSH_CTX_free(client.wolf_ctx);
+    if (client.pcb != NULL) {
+        struct altcp_pcb *pcb = client.pcb;
+        client.pcb = NULL;
+        altcp_arg(pcb, NULL); altcp_recv(pcb, NULL); altcp_sent(pcb, NULL);
+        altcp_poll(pcb, NULL, 0); altcp_err(pcb, NULL);
+        if (altcp_close(pcb) != ERR_OK) altcp_abort(pcb);
+    }
+    free_keys();
+    memset(&client, 0, sizeof(client));
+    if (saved_size != 0u) {
+        memcpy(client.password, saved_password, saved_size);
+        client.password_size = saved_size;
+        memset(saved_password, 0, sizeof(saved_password));
+    }
+}
+
+static void close_client(void) { close_connection(false); }
+
+static uint8_t start_connection(const char *url, const char *username,
+                                int trust_unknown, bool sftp_mode)
+{
+    err_t result;
+    if (parse_url(url) != 0 || *username == '\0' ||
+        strlen(username) >= sizeof(client.username)) return NTS_ERR_PARAM;
+    strcpy(client.username, username);
+    client.sftp_mode = sftp_mode;
+    client.trust_unknown = trust_unknown != 0;
+    if (load_keys() != 0) {
+        free_keys();
+        if (client.password_size == 0u) return NTS_AUTH_FAILED;
+    }
+    result = dns_gethostbyname(client.host, &client.address, dns_found, &client);
+    if (result == ERR_INPROGRESS) { client.stage = SSH_RESOLVING; return NTS_PENDING; }
+    if (result != ERR_OK) return NTS_ERR_DNS;
+    client.dns_done = client.dns_ok = true;
+    client.stage = SSH_RESOLVING;
+    return NTS_PENDING;
+}
+
+static uint8_t start_tcp(void)
+{
+    if (!client.dns_done) return NTS_PENDING;
+    if (!client.dns_ok) return NTS_ERR_DNS;
+    if (!wifi_lwip_get_context()->address_ready) return NTS_PENDING;
+    client.pcb = altcp_new_ip_type(NULL, IPADDR_TYPE_V4);
+    if (client.pcb == NULL) return NTS_ERR_CONN;
+#if !LWIP_ALTCP
+    client.pcb->rcv_wnd = SSH_RX_SIZE;
+    client.pcb->rcv_ann_wnd = SSH_RX_SIZE;
+#endif
+    altcp_arg(client.pcb, &client);
+    altcp_recv(client.pcb, nts_tcp_recv);
+    altcp_err(client.pcb, nts_tcp_error);
+    if (altcp_connect(client.pcb, &client.address, client.port,
+                      nts_tcp_connected) != ERR_OK) return NTS_ERR_CONN;
+    client.stage = SSH_CONNECTING;
+    return NTS_PENDING;
+}
+
+static uint8_t start_wolfssh(void)
+{
+    client.wolf_ctx = wolfSSH_CTX_new(WOLFSSH_ENDPOINT_CLIENT, NULL);
+    if (client.wolf_ctx == NULL) return NTS_ERR_CONN;
+    wolfSSH_SetIORecv(client.wolf_ctx, io_recv);
+    wolfSSH_SetIOSend(client.wolf_ctx, io_send);
+    wolfSSH_SetUserAuth(client.wolf_ctx, auth_callback);
+    wolfSSH_CTX_SetPublicKeyCheck(client.wolf_ctx, hostkey_callback);
+    client.ssh = wolfSSH_new(client.wolf_ctx);
+    if (client.ssh == NULL ||
+        wolfSSH_SetUsername(client.ssh, client.username) != WS_SUCCESS)
+        return NTS_ERR_CONN;
+    if (!client.sftp_mode &&
+        wolfSSH_SetChannelType(client.ssh, WOLFSSH_SESSION_TERMINAL,
+                               NULL, 0) != WS_SUCCESS)
+        return NTS_ERR_CONN;
+    wolfSSH_SetIOReadCtx(client.ssh, &client);
+    wolfSSH_SetIOWriteCtx(client.ssh, &client);
+    wolfSSH_SetUserAuthCtx(client.ssh, &client);
+    wolfSSH_SetPublicKeyCheckCtx(client.ssh, &client);
+    return NTS_PENDING;
+}
+
+static uint8_t port_open_mode(void *opaque, const char *url,
+                              const char *username, int trust_unknown,
+                              char fingerprint[96], bool sftp_mode)
+{
+    int result;
+    uint8_t status = NTS_PENDING;
+    (void)opaque;
+    if (client.stage != SSH_IDLE && client.sftp_mode != sftp_mode)
+        return NTS_ERR_INUSE;
+    switch (client.stage) {
+    case SSH_IDLE: status = start_connection(url, username, trust_unknown,
+                                              sftp_mode); break;
+    case SSH_RESOLVING: status = start_tcp(); break;
+    case SSH_CONNECTING: return NTS_PENDING;
+    case SSH_HANDSHAKE:
+        if (client.ssh == NULL) {
+            status = start_wolfssh();
+            if (status != NTS_PENDING) break;
+        }
+        result = client.sftp_mode ? wolfSSH_SFTP_connect(client.ssh) :
+                                    wolfSSH_connect(client.ssh);
+        if (result == WS_SUCCESS) {
+            free_keys();
+            clear_password();
+            client.stage = client.sftp_mode ? SSH_UP : SSH_RESIZE;
+            if (client.sftp_mode) {
+                strcpy(client.sftp_cwd, ".");
+                return NTS_OK;
+            }
+            return NTS_PENDING;
+        }
+        if (want_io(result)) return NTS_PENDING;
+        strcpy(fingerprint, client.fingerprint);
+        status = client.host_unknown ? NTS_HOSTKEY_UNKNOWN :
+                 (client.host_changed ? NTS_ERR_PROTOCOL : NTS_AUTH_FAILED);
+        break;
+    case SSH_RESIZE:
+        result = wolfSSH_ChangeTerminalSize(client.ssh, 40u, 24u, 0u, 0u);
+        if (result == WS_SUCCESS) { client.stage = SSH_UP; return NTS_OK; }
+        if (want_io(result)) return NTS_PENDING;
+        status = NTS_ERR_PROTOCOL;
+        break;
+    case SSH_UP: return NTS_OK;
+    case SSH_FAILED: status = NTS_ERR_CONN; break;
+    }
+    if (status != NTS_PENDING)
+        close_connection(status == NTS_HOSTKEY_UNKNOWN);
+    return status;
+}
+
+static uint8_t port_open(void *opaque, const char *url, const char *username,
+                         int trust_unknown, char fingerprint[96])
+{
+    return port_open_mode(opaque, url, username, trust_unknown, fingerprint,
+                          false);
+}
+
+static uint8_t port_sftp_open(void *opaque, const char *url,
+                              const char *username, int trust_unknown,
+                              char fingerprint[96])
+{
+    return port_open_mode(opaque, url, username, trust_unknown, fingerprint,
+                          true);
+}
+
+static bool sftp_want_io(void)
+{
+    int error = client.ssh != NULL ? wolfSSH_get_error(client.ssh) : 0;
+    return error == WS_WANT_READ || error == WS_WANT_WRITE ||
+           error == WS_REKEYING;
+}
+
+static int sftp_fail_or_pending(void)
+{
+    return sftp_want_io() ? -(int)NTS_PENDING : -(int)NTS_ERR_PROTOCOL;
+}
+
+static int sftp_resolve_path(const char *path, char out[512])
+{
+    int count;
+    if (path == NULL) return -1;
+    if (*path == '/' || !strcmp(client.sftp_cwd, "."))
+        count = snprintf(out, 512u, "%s", *path != '\0' ? path : ".");
+    else
+        count = snprintf(out, 512u, "%s/%s", client.sftp_cwd,
+                         *path != '\0' ? path : ".");
+    return count > 0 && count < 512 ? 0 : -1;
+}
+
+static int sftp_copy_name(WS_SFTPNAME *name, uint8_t *out, size_t maximum)
+{
+    size_t used = 0;
+    for (WS_SFTPNAME *entry = name; entry != NULL; entry = entry->next) {
+        const char *text = entry->lName != NULL ? entry->lName : entry->fName;
+        size_t length = text != NULL ? strlen(text) : 0u;
+        if (length + 1u > maximum - used) return -(int)NTS_ERR_PROTOCOL;
+        memcpy(out + used, text, length);
+        used += length;
+        out[used++] = '\n';
+    }
+    return (int)used;
+}
+
+static int port_sftp_path(void *opaque, uint8_t operation, const char *path,
+                          uint8_t *out, size_t maximum)
+{
+    char full[512];
+    int result;
+    WS_SFTPNAME *names;
+    (void)opaque;
+    if (client.stage != SSH_UP || !client.sftp_mode ||
+        sftp_resolve_path(path, full) != 0)
+        return -(int)NTS_ERR_CONN;
+    switch (operation) {
+    case NTS_SEC_SFTP_PWD: {
+        size_t length = strlen(client.sftp_cwd);
+        if (length + 1u > maximum) return -(int)NTS_ERR_PARAM;
+        memcpy(out, client.sftp_cwd, length);
+        out[length++] = '\n';
+        return (int)length;
+    }
+    case NTS_SEC_SFTP_CD:
+        names = wolfSSH_SFTP_RealPath(client.ssh, full);
+        if (names == NULL) return sftp_fail_or_pending();
+        if (names->fName == NULL || strlen(names->fName) >= sizeof(client.sftp_cwd)) {
+            wolfSSH_SFTPNAME_list_free(names);
+            return -(int)NTS_ERR_PROTOCOL;
+        }
+        strcpy(client.sftp_cwd, names->fName);
+        wolfSSH_SFTPNAME_list_free(names);
+        return 0;
+    case NTS_SEC_SFTP_LS:
+        names = wolfSSH_SFTP_LS(client.ssh, full);
+        if (names == NULL) {
+            int error = wolfSSH_get_error(client.ssh);
+            if (sftp_want_io()) return -(int)NTS_PENDING;
+            return error == WS_SUCCESS || error == WOLFSSH_FTP_EOF ? 0 :
+                   -(int)NTS_ERR_PROTOCOL;
+        }
+        result = sftp_copy_name(names, out, maximum);
+        wolfSSH_SFTPNAME_list_free(names);
+        return result;
+    case NTS_SEC_SFTP_DELETE:
+        result = wolfSSH_SFTP_Remove(client.ssh, full);
+        break;
+    case NTS_SEC_SFTP_MKDIR:
+        result = wolfSSH_SFTP_MKDIR(client.ssh, full, NULL);
+        break;
+    case NTS_SEC_SFTP_RMDIR:
+        result = wolfSSH_SFTP_RMDIR(client.ssh, full);
+        break;
+    default:
+        return -(int)NTS_ERR_PARAM;
+    }
+    if (result == WS_SUCCESS) return 0;
+    return sftp_fail_or_pending();
+}
+
+static int port_sftp_transfer_open(const char *path, bool upload)
+{
+    char full[512];
+    word32 flags = upload ? (WOLFSSH_FXF_WRITE | WOLFSSH_FXF_CREAT |
+                             WOLFSSH_FXF_TRUNC) : WOLFSSH_FXF_READ;
+    int result;
+    if (client.stage != SSH_UP || !client.sftp_mode ||
+        client.sftp_transfer != 0u || sftp_resolve_path(path, full) != 0)
+        return -(int)NTS_ERR_CONN;
+    client.sftp_handle_size = sizeof(client.sftp_handle);
+    result = wolfSSH_SFTP_Open(client.ssh, full, flags, NULL,
+                               client.sftp_handle,
+                               &client.sftp_handle_size);
+    if (result != WS_SUCCESS) return sftp_fail_or_pending();
+    client.sftp_offset[0] = client.sftp_offset[1] = 0u;
+    client.sftp_transfer = upload ? 2u : 1u;
+    return 0;
+}
+
+static int port_sftp_get_open(void *opaque, const char *path)
+{
+    (void)opaque;
+    return port_sftp_transfer_open(path, false);
+}
+
+static int port_sftp_put_open(void *opaque, const char *path)
+{
+    (void)opaque;
+    return port_sftp_transfer_open(path, true);
+}
+
+static void sftp_advance(word32 amount)
+{
+    word32 old = client.sftp_offset[0];
+    client.sftp_offset[0] += amount;
+    if (client.sftp_offset[0] < old) client.sftp_offset[1]++;
+}
+
+static int port_sftp_get_read(void *opaque, uint8_t *out, size_t maximum)
+{
+    int result;
+    (void)opaque;
+    if (client.sftp_transfer != 1u || maximum > UINT32_MAX)
+        return -(int)NTS_ERR_CONN;
+    result = wolfSSH_SFTP_SendReadPacket(client.ssh, client.sftp_handle,
+                                         client.sftp_handle_size,
+                                         client.sftp_offset, out,
+                                         (word32)maximum);
+    if (result >= 0) {
+        sftp_advance((word32)result);
+        return result;
+    }
+    return sftp_fail_or_pending();
+}
+
+static int port_sftp_put_write(void *opaque, const uint8_t *data, size_t length)
+{
+    int result;
+    (void)opaque;
+    if (client.sftp_transfer != 2u || length == 0u || length > UINT32_MAX)
+        return -(int)NTS_ERR_PARAM;
+    result = wolfSSH_SFTP_SendWritePacket(client.ssh, client.sftp_handle,
+                                          client.sftp_handle_size,
+                                          client.sftp_offset,
+                                          (byte *)(uintptr_t)data,
+                                          (word32)length);
+    if (result >= 0) {
+        if ((size_t)result != length) return -(int)NTS_ERR_PROTOCOL;
+        sftp_advance((word32)result);
+        return result;
+    }
+    return sftp_fail_or_pending();
+}
+
+static int port_sftp_transfer_close(void *opaque)
+{
+    int result;
+    (void)opaque;
+    if (client.sftp_transfer == 0u) return 0;
+    result = wolfSSH_SFTP_Close(client.ssh, client.sftp_handle,
+                                client.sftp_handle_size);
+    if (result != WS_SUCCESS) return sftp_fail_or_pending();
+    client.sftp_transfer = 0u;
+    client.sftp_handle_size = 0u;
+    return 0;
+}
+
+static void port_sftp_close(void *opaque) { (void)opaque; close_client(); }
+
+static int port_read(void *opaque, uint8_t *out, size_t maximum)
+{
+    int result;
+    (void)opaque;
+    if (client.stage != SSH_UP || maximum > UINT32_MAX) return -(int)NTS_ERR_CONN;
+    result = wolfSSH_stream_read(client.ssh, out, (word32)maximum);
+    if (result >= 0) return result;
+    /* A normal remote shell exit closes the SSH channel before the peer must
+       close its TCP connection. Report that as EOF, not protocol error &2B. */
+    if (channel_finished(result)) return -(int)NTS_EOF;
+    if (want_io(result)) return 0;
+    return client.eof && client.rx_count == 0u ? -(int)NTS_EOF :
+                                                 -(int)NTS_ERR_PROTOCOL;
+}
+
+static int port_write(void *opaque, const uint8_t *data, size_t length)
+{
+    int result;
+    (void)opaque;
+    if (client.stage != SSH_UP || length > UINT32_MAX) return -(int)NTS_ERR_CONN;
+    result = wolfSSH_stream_send(client.ssh, (byte *)(uintptr_t)data,
+                                 (word32)length);
+    if (result >= 0) return result;
+    return want_io(result) ? 0 : -(int)NTS_ERR_PROTOCOL;
+}
+
+static int port_password(void *opaque, const uint8_t *password, size_t length)
+{
+    (void)opaque;
+    if (password == NULL || client.stage != SSH_IDLE || length == 0u ||
+        length > sizeof(client.password)) return -1;
+    clear_password();
+    memcpy(client.password, password, length);
+    client.password_size = (word32)length;
+    return 0;
+}
+
+static void port_close(void *opaque) { (void)opaque; close_client(); }
+
+static const nts_secure_port port = {
+    port_random, port_open, port_read, port_write, port_password, port_close,
+    port_sftp_open, port_sftp_path, port_sftp_get_open, port_sftp_get_read,
+    port_sftp_put_open, port_sftp_put_write, port_sftp_transfer_close,
+    port_sftp_close
+};
+
+const nts_secure_port *nts_pi_wolfssh_port(void) { return &port; }
+void *nts_pi_wolfssh_context(void) { return &client; }
+int nts_pi_wolfssh_ready(void) { return provider_ready; }
+int nts_pi_wolfssh_random_ready(void) { return rng_ready; }
+void nts_pi_wolfssh_poll(void)
+{
+    wifi_lwip_rx_kick();
+    rng_poll();
+    if (rng_ready && !wolfssh_init_attempted) {
+        wolfssh_init_attempted = true;
+        provider_ready = wolfSSH_Init() == WS_SUCCESS;
+        wolfssh_started = provider_ready;
+    }
+}
+
+void nts_pi_wolfssh_reset(void)
+{
+    close_client();
+    if (wolfssh_started) {
+        (void)wolfSSH_Cleanup();
+        wolfssh_started = false;
+    }
+    wolfssh_init_attempted = false;
+    (void)f_mkdir("Pi1MHz");
+    (void)f_mkdir(SSH_DIR);
+    provider_ready = false;
+    rng_begin();
+}

--- a/src/secure_service_wolfssh.h
+++ b/src/secure_service_wolfssh.h
@@ -1,0 +1,13 @@
+#ifndef PI1MHZ_SECURE_SERVICE_WOLFSSH_H
+#define PI1MHZ_SECURE_SERVICE_WOLFSSH_H
+
+#include "secure_service_core.h"
+
+const nts_secure_port *nts_pi_wolfssh_port(void);
+void *nts_pi_wolfssh_context(void);
+int nts_pi_wolfssh_ready(void);
+int nts_pi_wolfssh_random_ready(void);
+void nts_pi_wolfssh_poll(void);
+void nts_pi_wolfssh_reset(void);
+
+#endif

--- a/src/services.h
+++ b/src/services.h
@@ -22,7 +22,13 @@
 #define SERVICE_CMD_AUN_LAST    44u
 #define SERVICE_CMD_NET_FIRST   45u   /* IP sockets / N: device - net_service.c */
 #define SERVICE_CMD_NET_LAST    79u   /* sockets 45-56, IRQ 57, N: dev 60-65   */
-/* 80..255 unallocated */
+#define SERVICE_CMD_ELKWIFI_FIRST 80u /* ElkWiFi compatibility service        */
+/* 93 (UEF stream) and 86 (guard image) are deliberately unclaimed while the
+   UEF cluster is held back; leaving the range at 92 keeps them free. */
+#define SERVICE_CMD_ELKWIFI_LAST  92u
+#define SERVICE_CMD_SECURE_FIRST  94u /* RNG and managed SSH service          */
+#define SERVICE_CMD_SECURE_LAST  113u
+/* 120..255 unallocated */
 
 /* Handler for one service's command range.  FIQ context: called from the
    FRED write callback, so anything slow must be queued for the main loop

--- a/src/services_emulator.c
+++ b/src/services_emulator.c
@@ -31,7 +31,11 @@ typedef struct {
    service_command_fn handler;
 } service_range_t;
 
-#define SERVICES_MAX 4u
+/* Four sufficed for disc, FAT, AUN and net.  The 1MHz-WiFi ROM support adds
+   ElkWiFi and FTP, and SSH when PI1MHZ_SSH is on, so the table would overflow
+   and a service would silently fail to claim its range.  Eight entries cost
+   32 bytes of BSS. */
+#define SERVICES_MAX 8u
 static service_range_t s_services[SERVICES_MAX];
 static unsigned int s_service_count;
 

--- a/src/tests/net/stubs/Pi1MHz.h
+++ b/src/tests/net/stubs/Pi1MHz.h
@@ -10,6 +10,8 @@ typedef void (*func_ptr)(void);
 
 /* Small JIM window for tests: DISC_RAM_BASE 0, DISC_RAM_SIZE 64 KB (see
    ram_emulator.h), plus room for command blocks below the region. */
+/* Include the services-page address used by net_debug_mark as well as the
+   public test buffers. ASan can then detect a genuinely invalid access. */
 #ifdef COPY_PUBLIC_NONZERO_ONLY
 #define TEST_JIM_SIZE 0x1100000u
 #else

--- a/src/tests/services/fuzz_fat.c
+++ b/src/tests/services/fuzz_fat.c
@@ -65,6 +65,15 @@ unsigned char disk_type(void) { return 1; }
 bool filesystemMount(void) { return true; }
 bool filesystemDismount(void) { return true; }
 
+void net_service_command(uint32_t cp, uint32_t addr, uint8_t data)
+{ (void)cp; (void)addr; (void)data; }
+void elkwifi_service_command(uint32_t cp, uint32_t addr, uint8_t data)
+{ (void)cp; (void)addr; (void)data; }
+void secure_service_command(uint32_t cp, uint32_t addr, uint8_t data)
+{ (void)cp; (void)addr; (void)data; }
+void ftp_service_command(uint32_t cp, uint32_t addr, uint8_t data)
+{ (void)cp; (void)addr; (void)data; }
+
 /* config.c (linked for config_beeb_write_protected) references this. */
 uint32_t filesystemReadFile(const char *f, uint8_t **a, unsigned int m)
 { (void)f; (void)a; (void)m; return 0; }

--- a/src/tests/services/test_services.c
+++ b/src/tests/services/test_services.c
@@ -137,11 +137,17 @@ int main(void)
    puts("== registration ==");
    ok(services_register(SERVICE_CMD_AUN_FIRST, SERVICE_CMD_AUN_LAST, test_aun_handler),
       "AUN range registers");
+   ok(services_register(SERVICE_CMD_AUN_FIRST, SERVICE_CMD_AUN_LAST, test_aun_handler),
+      "identical reset-time claim renews without consuming a slot");
    ok(!services_register(25, 35, test_aun_handler), "overlapping range refused");
    ok(!services_register(10, 5, test_aun_handler), "inverted range refused");
    ok(services_register(50, 59, test_aun_handler), "third range registers");
    ok(services_register(60, 69, test_aun_handler), "fourth range registers");
-   ok(!services_register(70, 79, test_aun_handler), "table full refused");
+   ok(services_register(70, 79, test_aun_handler), "fifth range registers");
+   ok(services_register(80, 89, test_aun_handler), "sixth range registers");
+   ok(services_register(90, 99, test_aun_handler), "seventh range registers");
+   ok(services_register(100, 109, test_aun_handler), "eighth range registers");
+   ok(!services_register(110, 119, test_aun_handler), "table full refused");
 
    puts("== dispatch ==");
    ok(do_simple(0, 20) == 42, "FAT command 20 reaches disk_type");
@@ -150,9 +156,9 @@ int main(void)
       Pi1MHz->JIM_ram[cp] = 31;
       (void)dispatch(CMD_PAGE);
       ok(aun_calls == 1 && aun_last_cmd == 31, "command 31 routed to the AUN handler");
-      Pi1MHz->JIM_ram[cp] = 45;
+      Pi1MHz->JIM_ram[cp] = 200;
       uint8_t echo = dispatch(CMD_PAGE);
-      ok(echo == CMD_PAGE, "unclaimed command 45 ignored (echo only)");
+      ok(echo == CMD_PAGE, "unclaimed command 200 ignored (echo only)");
    }
 
    puts("== open-file interlock ==");

--- a/src/user_settings.h
+++ b/src/user_settings.h
@@ -1,0 +1,75 @@
+#ifndef NETTOOLS_WOLFSSL_USER_SETTINGS_H
+#define NETTOOLS_WOLFSSL_USER_SETTINGS_H
+
+/* wolfCrypt-only profile for the Pi1MHz SSH v2 client. */
+#define SINGLE_THREADED
+#define WOLFCRYPT_ONLY
+#define WOLFSSL_WOLFSSH
+#define WOLFSSL_NO_SOCK
+#define WOLFSSL_USER_IO
+#define NO_WRITEV
+#define NO_FILESYSTEM
+#define WOLFSSL_IGNORE_FILE_WARN
+#define SIZEOF_LONG_LONG 8
+#define WOLFSSL_GENERAL_ALIGNMENT 4
+
+#define WOLFSSH_USER_IO
+#define WOLFSSH_NO_SERVER
+#define NO_WOLFSSH_SERVER
+#define WOLFSSH_NO_DH_GEX_SHA256
+#define WOLFSSH_TERM
+#define WOLFSSH_SFTP
+#define WOLFSSH_FATFS
+#define WOLFSSH_MAX_SFTP_RW 256
+#define WOLFSSH_MAX_SFTP_RECV 4096
+#define WOLFSSH_MAX_SFTP_NAME 4096
+#define NO_TERMIOS
+#define DEFAULT_WINDOW_SZ 4096
+
+#define WOLFSSL_BASE64_ENCODE
+#define WOLFSSL_ASN_TEMPLATE
+#define WOLFSSL_PUBLIC_MP
+#define WOLFSSL_AES_COUNTER
+#define WOLFSSL_AES_DIRECT
+#define HAVE_AESGCM
+#define GCM_SMALL
+#define WOLFSSL_AES_SMALL_TABLES
+
+#define HAVE_CURVE25519
+#define HAVE_ED25519
+#define WOLFSSL_ED25519_STREAMING_VERIFY
+#define HAVE_ECC
+#define ECC_USER_CURVES
+#define ECC_TIMING_RESISTANT
+#define WOLFSSL_SHA512
+#define WOLFSSL_SHA384
+
+#define WOLFSSL_SP_MATH
+#define WOLFSSL_SP_SMALL
+#define WOLFSSL_HAVE_SP_RSA
+#define WOLFSSL_HAVE_SP_DH
+#define WOLFSSL_HAVE_SP_ECC
+#define TFM_TIMING_RESISTANT
+#define WC_RSA_BLINDING
+#define RSA_LOW_MEM
+#define WC_NO_RSA_OAEP
+#define NO_DSA
+
+#define WC_NO_HASHDRBG
+extern int nts_bcm_random_block(unsigned char *out, unsigned int length);
+#define CUSTOM_RAND_GENERATE_BLOCK nts_bcm_random_block
+
+#define NO_RC4
+#define NO_MD4
+#define NO_MD5
+#define NO_DES3
+#define NO_DES3_TLS_SUITES
+#define NO_PSK
+#define NO_PKCS12
+#define NO_PWDBASED
+#define NO_ERROR_STRINGS
+#define NO_SESSION_CACHE
+#define NO_OLD_TLS
+#define WC_NO_ASYNC_THREADING
+
+#endif

--- a/src/wifi/lwipopts.h
+++ b/src/wifi/lwipopts.h
@@ -6,7 +6,7 @@
 
 #define MEM_ALIGNMENT                   4
 
-#define LWIP_RAW                        0
+#define LWIP_RAW                        1
 #define LWIP_NETCONN                    0
 #define LWIP_SOCKET                     0
 


### PR DESCRIPTION
This is the Pi side of the 1MHz-WiFi project: WiFi networking and a streaming
cassette filing system for a BBC Micro or Acorn Electron over the 1MHz bus,
through an AP5 or similar interface. The host runs a sideways ROM; this is the
half it talks to. Offered in case you would rather carry it than have it live
downstream as a patch series, and equally happy for it to stay downstream.

**WiFi and SDIO** gain what a host-driven client needs: WPA and WPA2 security
selection, radio control, MAC fallback, join diagnostics and a join reference,
leave, scan cancellation, profile validation, an off state that releases lwIP
cleanly, and Pi 3B support.

**New services.** `elkwifi_service` serves the host command set over the mailbox
and JIM window. `ftp_service` and `secure_service` provide FTP, and SSH and SFTP
through wolfSSH. `uef_normalize` decompresses and normalises UEF cassette images
on the Pi so the host streams a flat image rather than parsing gzip or ZIP
itself. `media_catalogue` and `media_service_core` read the container catalogue.

**Service dispatch** is made deterministic here rather than separately. It
walked the registration table and took the first matching range, so which
handler served a command depended on registration order; adding these services
required pinning that, and the accompanying test fixes the capacity and mapping
so a later registration cannot quietly move an existing command.

## Why one pull request

You asked for self-contained chunks, and this is one: the parts do not stand
alone. The WiFi work modifies functions the integration introduces, and the
dispatch change references the command ranges these services define. I tried
splitting them and each piece failed to compile or test without the rest, so
splitting further would mean submitting parts that do not build.

Two things that *are* independent are offered separately: the gitversion fix
(#18) and the net_service corrections (#19).

## Verification

Upstream's own `src/tests/services/run_tests.sh` and `src/tests/net/run_tests.sh`
pass on this branch. The firmware builds for both kernel families.

## Notes

The file and symbol names still say `elkwifi` in places. The project began as an
adaptation of the ElkWiFi cartridge ROM; most of that code has been replaced
since, but the names are load bearing in our downstream patch series, so they
are left alone here rather than renamed in the same change.

One thing worth raising separately: `src/wifi/webserver.c` uses `__DATE__` and
`__TIME__`, so the kernel embeds a build timestamp and is not reproducible. Two
builds of the same source produce different images, which makes it impossible to
verify a shipped kernel against a commit. Happy to open that as its own issue if
useful.