### PR TITLE
services: raise the range table to eight entries

### DIFF
--- a/src/services_emulator.c
+++ b/src/services_emulator.c
@@ -31,7 +31,11 @@ typedef struct {
    service_command_fn handler;
 } service_range_t;
 
-#define SERVICES_MAX 4u
+/* Four covers disc, FAT, AUN and net. Optional services registering on top of
+   those overflow the table, and services_register then returns false at a call
+   site that usually discards it, so the range is silently never claimed.
+   Eight entries cost 32 bytes of BSS. */
+#define SERVICES_MAX 8u
 static service_range_t s_services[SERVICES_MAX];
 static unsigned int s_service_count;
 

--- a/src/tests/services/test_services.c
+++ b/src/tests/services/test_services.c
@@ -137,11 +137,17 @@ int main(void)
    puts("== registration ==");
    ok(services_register(SERVICE_CMD_AUN_FIRST, SERVICE_CMD_AUN_LAST, test_aun_handler),
       "AUN range registers");
+   ok(services_register(SERVICE_CMD_AUN_FIRST, SERVICE_CMD_AUN_LAST, test_aun_handler),
+      "identical reset-time claim renews without consuming a slot");
    ok(!services_register(25, 35, test_aun_handler), "overlapping range refused");
    ok(!services_register(10, 5, test_aun_handler), "inverted range refused");
    ok(services_register(50, 59, test_aun_handler), "third range registers");
    ok(services_register(60, 69, test_aun_handler), "fourth range registers");
-   ok(!services_register(70, 79, test_aun_handler), "table full refused");
+   ok(services_register(70, 79, test_aun_handler), "fifth range registers");
+   ok(services_register(80, 89, test_aun_handler), "sixth range registers");
+   ok(services_register(90, 99, test_aun_handler), "seventh range registers");
+   ok(services_register(100, 109, test_aun_handler), "eighth range registers");
+   ok(!services_register(110, 119, test_aun_handler), "table full refused");
 
    puts("== dispatch ==");
    ok(do_simple(0, 20) == 42, "FAT command 20 reaches disk_type");


### PR DESCRIPTION
`SERVICES_MAX` is four, which covers disc, FAT, AUN and net. Any further service
registering on top of those overflows the table, and because `services_register`
returns false at call sites which usually discard the result, the range is simply
never claimed and the service stops answering with no diagnostic.

Eight entries cost 32 bytes of BSS.

The services test only checked as far as the fourth range and then asserted the
table was full, so it could not tell the configured limit from a regression. It
now walks up to the eighth range and asserts refusal beyond that, and covers one
case that was previously untested: an identical re-registration, as happens on a
host reset, renews the existing claim rather than consuming another slot.

`src/tests/services/run_tests.sh` passes.

Branched from current master. Not run on hardware; covered by the host tests
above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)