### PR TITLE
beeb: add the 1MHz-WiFi host ROM

### DIFF
--- a/beeb/1mhz-wifi/README.md
+++ b/beeb/1mhz-wifi/README.md
@@ -1,0 +1,81 @@
+# 1MHz-WiFi host ROM
+
+A 16 KiB sideways ROM that drives the Pi1MHz WiFi and net services from a BBC
+Micro, B+, Master or Acorn Electron. It is the host half of `wifi_service` and
+`net_service`: those provide the radio, the sockets and the URL fetch, and this
+provides the star commands and the OSWORD `&65` entry that applications call.
+
+Build it with beebasm:
+
+```sh
+./build.sh
+```
+
+That writes `src/1mhz-wifi.rom`. Put it in a sideways slot, or add it to
+`firmware/Pi1MHz/` and reference it from `Pi1MHz.cfg` to have Pi1MHz serve it.
+It is not wired into the CMake build and does not affect the firmware.
+
+## Commands
+
+| | |
+| ------------------------------------- | -------------------------------- |
+| `*JOIN <ssid> [password]`, `*LEAVE`    | associate and disassociate |
+| `*LAP`, `*LAPOPT [n]`                  | list access points, set scan options |
+| `*IFCFG`, `*ONLINE`, `*MODE`           | address configuration and readiness |
+| `*WIFI ON\|OFF`                        | radio control |
+| `*PING <host>`, `*NSLOOK <host>`       | reachability and name resolution |
+| `*DATE`, `*TIME`                       | network time |
+| `*WGET <url> [file]`                   | fetch, through the active filing system or a JIM window |
+| `*VERSION`, `*PRD`                     | identity, paged RAM dump |
+| `*RDINIT`, `*RDCAT`, `*RDSAVE`, `*RDLOAD`, `*RDRUN` | RAM disk |
+
+`*HELP WIFI` lists them on the machine.
+
+## The RAM disk
+
+The RAM disk holds 65,024 bytes in up to 15 files in the low 64 KiB JIM
+window, so a program can be fetched over the network and run without a filing
+system fitted. Page 0 is left to the OSWORD `&65` service reply buffer, page 1
+is the catalogue, and files follow from page 2 on page boundaries.
+
+It stays in JIM bank 0. That is the only bank an unmodified Electron AP5
+forwards, so a format using the upper banks at `&FCFD` and `&FCFE` would work
+on the BBC family and silently not on the Electron. Files are page aligned, so
+a short file still costs a whole page, and space is reclaimed only by
+`*RDINIT`, which clears the catalogue.
+
+## Machine differences
+
+One image runs on all four machines. The host is identified at run time with
+OSBYTE `&81`, and two differences follow from it. Sideways ROM selection is
+`&FE05` with the Electron deselect cycle against `&FE30` on the BBC family.
+The JIM selectors `&FCFD` and `&FCFE` exist on direct BBC-family systems and
+must be reasserted in every masked transaction, while an unmodified Electron
+AP5 does not forward them.
+
+The startup glyph is the third. The BBC family boots into MODE 7, where codes
+above 127 are teletext cells rather than soft characters, so the ROM reads the
+mode with OSBYTE 135 and prints the banner without the glyph there. The
+Electron has no teletext mode and is unaffected.
+
+## Transport
+
+The ROM writes a bounded command block to `&FCA6-&FCAA`, dispatches it, treats
+every status with bit 7 set as busy, yields with OSBYTE `&13`, checks Escape
+and applies a finite timeout. Escape sends command 90 so the Pi can discard a
+late DNS, ICMP, NTP or scan callback. After a service completes it masks
+interrupts, reselects the response cursor and copies the bounded reply before
+restoring the previous interrupt state, so IRQ-side MMFS or ADFS activity
+cannot move the cursor between the completion poll and the copy.
+
+It never reaches for the `&FC30` cartridge UART the original ElkWiFi hardware
+used.
+
+## Provenance
+
+Every file here was written for the 1MHz-WiFi project and carries no ElkWiFi
+or UPCFS lineage. The project began as an adaptation of Roland Leurs' ElkWiFi
+cartridge ROM, and the parts that still derive from it, together with Martin
+Barr's UPCFS, are the cassette filing system, which is not in this ROM and is
+not offered here. `*VERSION` credits ElkWiFi for the interface this ROM
+implements.

--- a/beeb/1mhz-wifi/build.sh
+++ b/beeb/1mhz-wifi/build.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+# Assemble the 1MHz-WiFi host ROM. Requires beebasm on PATH, or set BEEBASM.
+set -eu
+
+beebasm=${BEEBASM:-beebasm}
+cd "$(CDPATH= cd -- "$(dirname -- "$0")/src" && pwd)"
+"$beebasm" -i 1mhzwifi.asm
+
+size=$(wc -c < 1mhz-wifi.rom)
+if [ "$size" -ne 16384 ]; then
+    echo "1mhz-wifi.rom is $size bytes, expected 16384" >&2
+    exit 1
+fi
+echo "built $(pwd)/1mhz-wifi.rom"

--- a/beeb/1mhz-wifi/src/1mhzwifi.asm
+++ b/beeb/1mhz-wifi/src/1mhzwifi.asm
@@ -1,0 +1,358 @@
+\ 1mhzwifi.asm
+\ 1MHz-WiFi sideways ROM: image header, service entry and command dispatch.
+\
+\ Written for the 1MHz-WiFi project. This replaces the main file the ROM
+\ inherited from ElkWiFi 0.23, whose own command table search was in turn
+\ credited to Gerrit Hillebrand's ATOM GDOS 1.5. Neither is used here: the
+\ search below walks one table entry at a time with its own structure, and the
+\ service, help, banner and OSWORD paths are this project's.
+\
+\ The table format itself is kept, because it is what the entries are written
+\ in: an entry is the command name in ASCII, then the handler address high byte
+\ first. A name byte with bit 7 set cannot occur, so the high byte of an
+\ address doubles as the end of name marker, and a bare address with no name
+\ terminates the table because every handler lives above &8000.
+\
+\ Credit for the parts of this ROM that do still derive from ElkWiFi is carried
+\ in *VERSION, not here.
+
+include "machine.asm"
+
+\ ---------------------------------------------------------------------------
+\ Image headers
+\ ---------------------------------------------------------------------------
+\ The ATM header is a sixteen byte zero padded name followed by load address,
+\ execution address and length. It precedes the ROM so the image can be loaded
+\ by a development loader; the shipped image starts at romstart.
+
+.atmheader          equs "1mhzwifi.rom",0,0,0,0
+                    equw &1800
+                    equw &1800
+                    equw romend-romstart
+
+.romstart           equb 0                      \ no language entry
+                    equb 0
+                    equb 0
+                    jmp service
+                    equb &82                    \ service ROM, no language
+                    equb (copyright-romstart)   \ copyright offset
+                    equb &30                    \ binary version
+.romtitle           equs "1MHz-WiFi"
+                    equb 0
+.romversion         equs "0.1.67"
+.copyright          equb 0
+                    equs "(C)2026 Peter Clarke"
+                    equb 0
+
+\ The keyword *HELP matches on, stored reversed because the compare below walks
+\ it backwards from its last character.
+.commands           equs "IFIW"
+
+\ ---------------------------------------------------------------------------
+\ Service entry
+\ ---------------------------------------------------------------------------
+\ A is the reason code, X this ROM's slot, Y the reason argument. Anything not
+\ listed is passed on with A unchanged.
+
+.service            cmp #4                      \ unrecognised command
+                    beq command
+                    cmp #9                      \ *HELP
+                    beq help
+                    cmp #1                      \ post reset initialisation
+                    bne service_not_boot
+                    jmp autorun
+.service_not_boot   cmp #8                      \ unrecognised OSWORD
+                    bne service_not_osword
+                    jmp osword65
+.service_not_osword rts
+
+\ ---------------------------------------------------------------------------
+\ Command dispatch
+\ ---------------------------------------------------------------------------
+\ Match the command line against the table, honouring a trailing dot as an
+\ abbreviation. Every BNE after an INX below stands in for a JMP: X indexes the
+\ table and only returns to zero if the table passes 256 bytes, which would
+\ break the single byte indexing regardless.
+\
+\ X indexes the table and is left on an entry's address high byte
+\ when a match is found; Y indexes the command line and is left just past the
+\ matched text, which is where every handler expects to start reading its
+\ arguments.
+
+.command            tya                         \ A on exit belongs to the
+                    pha                         \ handler, so only X and Y are
+                    txa                         \ saved here
+                    pha
+                    cld
+                    ldx #0
+.cmd_entry          ldy #0
+                    jsr skipspace               \ Y indexes the first non-space
+                    dey                         \ the loop's iny puts it back
+.cmd_step           iny
+                    lda commandtable,x
+                    bmi cmd_dispatch            \ name ended: full match
+                    cmp (line),y
+                    bne cmd_mismatch
+                    inx
+                    bne cmd_step
+
+\ The character on the command line is not the one the table expects. A dot
+\ there means the user abbreviated this command, so accept the entry; anything
+\ else means this is a different command.
+.cmd_mismatch       lda (line),y
+                    cmp #'.'
+                    beq cmd_abbreviated
+.cmd_skip_name      lda commandtable,x
+                    bmi cmd_skip_address
+                    inx
+                    bne cmd_skip_name
+.cmd_skip_address   inx
+                    inx                         \ X now starts the next entry
+                    bne cmd_entry
+
+.cmd_abbreviated    iny                         \ step over the dot
+.cmd_abbrev_skip    lda commandtable,x
+                    bmi cmd_dispatch
+                    inx
+                    bne cmd_abbrev_skip
+
+.cmd_dispatch       sta zp+1                    \ A already holds the high byte
+                    lda commandtable+1,x
+                    sta zp
+                    jmp (zp)
+
+\ Reached through the table's terminating entry: no command matched.
+.command_x6         pla
+                    tax
+                    pla
+                    tay
+                    lda #4
+                    rts
+
+\ ---------------------------------------------------------------------------
+\ *HELP
+\ ---------------------------------------------------------------------------
+\ With no keyword, print the title and the keyword this ROM answers to, then
+\ pass the call on so other ROMs also report. With the keyword, print the
+\ command list and claim the call.
+
+.help               tya
+                    pha
+                    txa
+                    pha
+                    lda (line),y
+                    cmp #&D
+                    beq help_l2
+                    ldx #3                      \ compare backwards against
+.help_l1            lda (line),y                \ the reversed keyword
+                    cmp commands,x
+                    bne help_l3
+                    iny
+                    dex
+                    bpl help_l1
+                    jsr print_help
+                    jmp call_claimed
+.help_l2            jsr help_version
+                    jsr printtext
+                    equb &D,&20,&20
+                    equs "WIFI",&D,&EA
+.help_l3            pla
+                    tax
+                    pla
+                    tay
+                    lda #9
+                    rts
+
+\ ---------------------------------------------------------------------------
+\ Reset
+\ ---------------------------------------------------------------------------
+\ Answered on reason 1 rather than 3, because a higher priority ROM may claim
+\ 3 before this one sees it. The MOS banner is suppressed and replaced, so the
+\ machine reports one identity rather than two.
+
+.autorun            tya
+                    pha
+                    txa
+                    pha
+
+
+                    \ Nothing here may touch the AP5 JIM selector: the ROM scan
+                    \ runs with another ROM's page possibly selected, and every
+                    \ command selects its own page when it starts.
+                    lda #&D7                    \ suppress the default banner
+                    ldx #0
+                    stx mux_status              \ no connection multiplexing yet
+                    ldy #&7F
+                    jsr osbyte
+
+                    jsr printtext
+                    equs "1MHz-WiFi 0.1.67",&EA
+
+                    ldy #&FF                    \ OSBYTE &FD: last reset type
+                    ldx #&00
+                    lda #&FD
+                    jsr osbyte
+                    cpx #0                      \ soft reset stays quiet
+                    beq autorun_l1
+                    lda #7
+                    jsr oswrch
+                    cpx #1
+                    bne autorun_l1
+.autorun_l1         jsr print_logo
+                    jsr printtext
+                    equb &D,&EA
+                    pla
+                    tax
+                    pla
+                    tay
+                    lda #1
+                    rts
+
+\ ---------------------------------------------------------------------------
+\ Command table
+\ ---------------------------------------------------------------------------
+\ Longer names must precede any name they begin with, so LAPOPT is listed
+\ before LAP and QUPRUN before QR.
+
+.commandtable       equs "WGET"
+                    equb >pi_wget_cmd, <pi_wget_cmd
+                    equs "WIFI"
+                    equb >wifi_cmd, <wifi_cmd
+                    equs "VERSION"
+                    equb >version_cmd, <version_cmd
+                    equs "LAPOPT"
+                    equb >lapopt_cmd, <lapopt_cmd
+                    equs "LAP"
+                    equb >lap_cmd, <lap_cmd
+                    equs "IFCFG"
+                    equb >ifcfg_cmd, <ifcfg_cmd
+                    equs "DATE"
+                    equb >date_cmd, <date_cmd
+                    equs "TIME"
+                    equb >time_cmd, <time_cmd
+                    equs "PRD"
+                    equb >pdump_cmd, <pdump_cmd
+                    equs "ONLINE"
+                    equb >online_cmd, <online_cmd
+                    equs "JOIN"
+                    equb >join_cmd, <join_cmd
+                    equs "LEAVE"
+                    equb >leave_cmd, <leave_cmd
+                    equs "PING"
+                    equb >ping_cmd, <ping_cmd
+                    equs "NSLOOK"
+                    equb >nslook_cmd, <nslook_cmd
+                    equs "RDINIT"
+                    equb >rd_init_cmd, <rd_init_cmd
+                    equs "RDCAT"
+                    equb >rd_cat_cmd, <rd_cat_cmd
+                    equs "RDLOAD"
+                    equb >rd_load_cmd, <rd_load_cmd
+                    equs "RDSAVE"
+                    equb >rd_save_cmd, <rd_save_cmd
+                    equs "RDRUN"
+                    equb >rd_run_cmd, <rd_run_cmd
+                    equs "MODE"
+                    equb >mode_cmd, <mode_cmd
+                    equs "DISCONNECT"
+                    equb >disconnect_cmd, <disconnect_cmd
+                    equb >command_x6, <command_x6
+
+\ Print the ROM title and version, with the separating zero shown as a space.
+.help_version       ldx #0
+.help_vl1           lda romtitle,x
+                    bne help_vl2
+                    lda #&20
+.help_vl2           jsr osasci
+                    inx
+                    cpx #(copyright-romtitle)
+                    bne help_vl1
+                    rts
+
+.print_help         jsr help_version
+                    jsr printtext
+                    equb &0D
+                    \ 40 "----- This string is 40 characters -----"
+                    equs " DATE      Print current date",&0D
+                    equs " IFCFG     Print IP and MAC address",&0D
+                    equs " JOIN      Join a network",&0D
+                    equs " LAP       List access points",&0D
+                    equs " LAPOPT    Set LAP options",&0D
+                    equs " LEAVE     Disconnect from network",&0D
+                    equs " MODE      Set device mode",&0D
+                    equs " ONLINE    Show network readiness",&0D
+                    equs " PING      ping a host on network",&0D
+                    equs " NSLOOK    Resolve an IPv4 address",&0D
+                    equs " PRD       Paged Ram Dump",&0D
+                    equs " RDCAT     Catalogue the RAM disk",&0D
+                    equs " RDINIT    Clear the RAM disk",&0D
+                    equs " RDLOAD    Load from the RAM disk",&0D
+                    equs " RDRUN     Run from the RAM disk",&0D
+                    equs " RDSAVE    Save to the RAM disk",&0D
+                    equs " TIME      Print current time",&0D
+                    equs " VERSION   Print firmware version",&0D
+                    equs " WGET      Get a file from a webserver",&0D
+                    equs " WIFI      WiFi control ON|OFF|HR|SR",&0D
+                    equb &EA
+.print_help_end     rts
+
+\ ---------------------------------------------------------------------------
+\ OSWORD &65
+\ ---------------------------------------------------------------------------
+\ The public driver entry, so applications can call the WiFi functions the
+\ commands use. This is the ElkWiFi compatibility interface and its shape is
+\ fixed by the clients that already call it: &EF holds the OSWORD number and
+\ &F0/&F1 point at a block whose first three bytes are the A, X and Y the
+\ driver should see. Every register may be modified.
+
+.osword65           lda &EF
+                    cmp #&65
+                    beq osword65_l1
+                    lda #8                      \ not ours, pass it on
+                    rts
+.osword65_l1        tya
+                    pha
+                    txa
+                    pha
+                    ldy #0
+                    lda (&F0),y                 \ function number
+                    pha
+                    iny
+                    lda (&F0),y
+                    tax
+                    iny
+                    lda (&F0),y
+                    tay
+                    pla
+                    jsr wifidriver
+                    jmp call_claimed
+
+include "util.asm"
+include "errors.asm"
+include "serial.asm"
+include "service_driver.asm"
+include "net_transport.asm"   \ after service_driver.asm, which sizes its workspace
+include "driver.asm"
+include "version.asm"
+include "time.asm"
+include "lap.asm"
+include "ifcfg.asm"
+include "online.asm"
+include "wificmd.asm"
+include "pdump.asm"
+include "join.asm"
+include "mode.asm"
+include "wget.asm"
+include "net_wget.asm"
+include "ping.asm"
+include "nslook.asm"
+include "ramdisk.asm"
+
+rom_content_end = P%
+ASSERT rom_content_end <= &BF00
+
+skipto &C000
+.romend
+
+SAVE "1mhz-wifi-atm.rom", atmheader, romend
+SAVE "1mhz-wifi.rom", romstart, romend

--- a/beeb/1mhz-wifi/src/driver.asm
+++ b/beeb/1mhz-wifi/src/driver.asm
@@ -1,0 +1,219 @@
+\ ElkWiFi-compatible driver for the Pi1MHz 1 MHz-bus service
+\ (c) Roland Leurs, May 2020
+
+\ Main service ROM
+\ Version 1.00
+
+\ AP5/Pi1MHz exposes &FCFF as a write-only JIM page selector. Keep the shadow
+\ and transient machine type in the service driver's private block. The stock
+\ `heap` at &0900 is ADFS/application workspace and is not safe during OSWORD.
+driver_page_shadow = drv_svc_workspace+19
+driver_machine = drv_svc_workspace+20
+driver_function = drv_svc_workspace+21
+driver_entry_x = drv_svc_workspace+22
+driver_entry_y = drv_svc_workspace+23
+
+\ Please note that some functions or routines are not quite logical
+\ but they are implemented to keep driver compatibility with the 
+\ Atom wifi driver.
+
+.wifidriver
+ \ entries are.
+ \ 00 init                12 cipstatus
+ \ 01 reset               13 cipsend
+ \ 02 gmr                 14 cipclose
+ \ 03 cwlap               15 cipserver
+ \ 04 cwjap               16 cipsto
+ \ 05 cwqap               17 ciobaud
+ \ 06 cwsap               18 cifsr
+ \ 07 cwmode              19 ciupdate
+ \ 08 cipstart            20 ipd
+ \ 09 cpmux               21 csyswdtenable
+ \ 10 cwlif               22 csyswdtdisable
+ \ 11 setbuffer           23 getmuxchannel
+ \ 24 disable/enable
+ \ 25 cwlapopt
+ \ 26 sslbufsize
+ \ 27 cipmode
+ \ 28 ping
+ \ 29-31 reserved
+
+ sta save_a                 \ save registers
+ stx save_x
+ sty save_y
+ sta driver_function
+ stx driver_entry_x
+ sty driver_entry_y
+ \ OSBYTE &81 with X=0,Y=&FF is the documented machine-type query. Run it
+ \ before touching the JIM high selectors and retain the result only for this
+ \ driver call; it is not valid as a reset-time cache.
+ lda #&81
+ ldx #0
+ ldy #&FF
+ jsr osbyte
+ stx driver_machine
+ jsr set_bank_0             \ ElkWiFi buffers are in JIM address 00:00:page
+ lda #0
+ sta driver_page_shadow
+ \ ElkWiFi 0.23 masks public function numbers to five bits after handling its
+ \ private flash entry. DATE, TIME and ONLINE call Pi routines directly and
+ \ therefore do not consume public driver numbers 32-34.
+ lda driver_function
+ and #&1F
+ asl a
+ tax
+ lda public_driver_dispatch+1,x
+ pha
+ lda public_driver_dispatch,x
+ pha
+ ldx driver_entry_x
+ ldy driver_entry_y
+ lda driver_function
+ and #&1F
+ rts
+
+; RTS dispatch preserves the JMP-style handler entry stack while reducing the
+; public 0-31 ABI to one auditable table. Entries contain target minus one.
+.public_driver_dispatch
+ equw service_driver_init-1
+ equw service_driver_reset-1
+ equw service_driver_version-1
+ equw service_driver_scan-1
+ equw service_driver_join-1
+ equw service_driver_leave-1
+ equw service_driver_ifcfg-1
+ equw service_driver_mode-1
+ equw service_driver_cipstart-1
+ equw service_driver_cpmux-1
+ equw service_driver_connection_status-1
+ equw service_driver_set_buffer-1
+ equw service_driver_connection_status-1
+ equw service_driver_cipsend-1
+ equw service_driver_cipclose-1
+ equw service_driver_baud_compat-1
+ equw service_driver_baud_compat-1
+ equw service_driver_baud_compat-1
+ equw service_driver_ifcfg-1
+ equw service_driver_unsupported-1
+ equw service_driver_ipd-1
+ equw service_driver_ok-1
+ equw service_driver_ok-1
+ equw service_driver_mux_channel-1
+ equw service_driver_wifi_control-1
+ equw service_driver_lapopt-1
+ equw service_driver_ok-1
+ equw service_driver_mode_unsupported-1
+ equw service_driver_ping-1
+ equw service_driver_unsupported-1
+ equw service_driver_unsupported-1
+ equw service_driver_unsupported-1
+\ Initialize the data buffer, by resetting the paged ram register to 0. This
+\ call does not clear the buffer and will mostly be called after a command
+\ is executed and the response is processed.
+.reset_buffer
+ php
+ sei
+ lda #0
+ sta driver_page_shadow
+ jsr select_public_page_a
+ ldx #&00               \ callers read the buffer from its first byte
+ plp
+ rts
+
+\ Initialize the data buffer, by resetting the paged ram register to 0
+\ and clearing the first byte. After a command is executed and if the first
+\ byte is 0 then there was no response from the ESP8266. This call is intended
+\ before a command is executed.
+.clear_buffer
+ jsr reset_buffer
+ php
+ sei
+ txa
+ jsr select_public_page_a
+ stx pageram
+ jsr bus_delay
+ plp
+; txa
+;.irb_l1
+; sta pageram,x
+; inx
+; bne irb_l1
+ rts
+
+\ Reads a character from the paged ram buffer at position X
+\ returns the character in A and the X register points 
+\ to the next data byte.
+.read_buffer
+ php
+ sei
+ lda driver_page_shadow
+ jsr select_public_page_a
+ lda pageram,x
+ plp
+ jsr read_buffer_inc
+ ora #0                    \ return N/Z for the byte read
+ rts
+.read_buffer_inc
+ inx
+ beq read_buffer_page_over  \ X wrapped, so the JIM page is exhausted
+ rts
+.read_buffer_page_over
+ jmp inc_page_reg
+
+\ Writes a character to the paged ram buffer at position X
+\ returns with X pointing to the next byte
+.write_buffer
+ php
+ sei
+ pha
+ lda driver_page_shadow
+ jsr select_public_page_a
+ pla
+ sta pageram,x
+ jsr bus_delay
+ plp
+ jmp read_buffer_inc
+
+\ Decrements the 24 bit data pointer. On the Electron most transfers will be smaller than
+\ 64 KB but it is possible to send up to 4 MB per transfer.
+.dec_data_counter
+ lda data_counter           \ borrow only into the bytes that need it
+ bne dec_data_counter_low
+ lda data_counter+1
+ bne dec_data_counter_mid
+ dec data_counter+2
+.dec_data_counter_mid
+ dec data_counter+1
+.dec_data_counter_low
+ dec data_counter
+ lda data_counter           \ Z set once all three bytes are zero
+ ora data_counter+1
+ ora data_counter+2
+ rts
+\ Finalise a Pi1MHz response buffered in JIM.
+.restore_env
+.set_buffer
+ stx datalen            \ save end of data
+ ldx driver_page_shadow
+ stx datalen+1
+ ldx datalen            \ restore x register
+rts
+
+\ Increments the paged ram register and sets the (X) pointer to the beginning of the page. 
+\ If the end of paged ram has been reached then the page register will roll over from &FF
+\ to &00 and the Z flag is set. The pageregister and X will not be updated and the routine
+\ returns with Z=1. The calling routine can test this flag for the end of buffer.
+.inc_page_reg
+ ldx driver_page_shadow \ use the write-only page register's RAM shadow
+ inx                    \ increment the value
+ beq buffer_end         \ if it becomes zero then the end of the buffer (paged ram) is reached
+ stx driver_page_shadow
+ php
+ sei
+ txa
+ jsr select_public_page_a \ write back to page register (i.e. select next page)
+ plp
+ ldx #0                 \ reset y register
+ cpx #1                 \ clears Z-flag
+.buffer_end
+ rts                    \ return to store routine

--- a/beeb/1mhz-wifi/src/errors.asm
+++ b/beeb/1mhz-wifi/src/errors.asm
@@ -1,0 +1,44 @@
+\ ElkWiFi-compatible MOS error construction.
+\
+\ The original Electron ROM used &0100 as a temporary BRK block. That is the
+\ processor stack, so a driver error entered by an application could overwrite
+\ live return addresses and subsequently report Bad program. 1MHzWifi removes
+\ the network printer and therefore owns its original 32-byte `netprt` block.
+\ The longest emitted error, including BRK, number and terminator, fits there.
+
+error_workspace = netprt
+
+.error
+    lda #&00
+    tay
+    sta error_workspace
+    lda #&00
+    sta error_workspace+1
+.error_loop
+    lda error_table,x
+    cmp #&0D
+    beq error_exec
+    sta error_workspace+2,y
+    inx
+    iny
+    bne error_loop
+.error_exec
+    lda #&00
+    sta error_workspace+2,y
+    jmp error_workspace
+
+.error_table
+.error_device_not_found equs "Device not found",&0D
+.error_no_response      equs "No response from device",&0D
+.error_buffer_full      equs "Buffer full",&0D
+.error_buffer_empty     equs "Buffer empty",&0D
+.error_no_date_time     equs "No date/time received",&0D
+.error_no_version       equs "No version received",&0D
+.error_not_implemented  equs "Not implemented",&0D
+.error_bad_option       equs "Unknown option",&0D
+.error_bad_protocol     equs "Unknown protocol",&0D
+.error_http_status      equs "HTTP error",&0D
+.error_no_pagedram      equs "No paged ram",&0D
+.error_disabled         equs "Wifi is disabled",&0D
+.error_opencon          equs "Connect error",&0D
+.error_bad_param        equs "Wrong parameter",&0D

--- a/beeb/1mhz-wifi/src/ifcfg.asm
+++ b/beeb/1mhz-wifi/src/ifcfg.asm
@@ -1,0 +1,11 @@
+\ ifcfg.asm
+\ 1MHz-WiFi ROM: *IFCFG.
+\
+\ Written for the 1MHz-WiFi project, replacing the inherited version.
+\
+\   *IFCFG          report the interface address configuration
+\
+\ Driver call 18 takes no parameters and prints its own reply.
+
+.ifcfg_cmd          lda #18
+                    jmp generic_cmd

--- a/beeb/1mhz-wifi/src/join.asm
+++ b/beeb/1mhz-wifi/src/join.asm
@@ -1,0 +1,75 @@
+\ join.asm
+\ 1MHz-WiFi ROM: *JOIN and *LEAVE.
+\
+\ Written for the 1MHz-WiFi project, replacing the inherited version.
+\
+\   *JOIN <ssid> [password]     associate, prompting for the password if it was
+\                               not given on the command line
+\   *JOIN ?                     report the network currently associated
+\   *LEAVE                      disassociate
+\
+\ Both build a parameter block at heap and hand it to the driver, which is what
+\ generic_cmd expects in X and Y.
+
+.join_cmd           jsr skipspace1
+                    jsr read_cli_param          \ X is the parameter length
+                    cpx #&00
+                    bne join_have_ssid
+                    jsr printtext
+                    equs "Usage: JOIN <ssid> [password]",&0D,&EA
+                    jmp call_claimed
+
+.join_have_ssid     ldx #0                      \ start the parameter block
+                    jsr copy_to_heap
+                    lda heap
+                    cmp #'?'
+                    beq query_network
+
+                    stx save_x                  \ where the password will go
+                    jsr skipspace1
+                    jsr read_cli_param
+                    cpx #0
+                    bne copy_password
+
+\ No password on the command line, so read one from the keyboard without
+\ echoing it. read_cli_param left X at zero, but set it here rather than rely
+\ on that.
+                    jsr printtext
+                    equs "Enter password: ",&EA
+                    ldx #0
+.enter_password     jsr osrdch
+                    cmp #&7F
+                    beq delete
+                    sta strbuf,x                \ the carriage return is stored
+                    pha                         \ too, and terminates the copy
+                    lda #'*'
+                    jsr oswrch
+                    pla
+                    inx
+                    bmi copy_password           \ 128 characters is enough
+                    cmp #&0D
+                    bne enter_password
+                    jsr osnewl
+
+.copy_password      ldx save_x
+                    jsr copy_to_heap
+                    jmp join_network
+
+.delete             cpx #0
+                    beq enter_password          \ nothing to rub out yet
+                    jsr oswrch
+                    dex
+                    bpl enter_password
+
+\ *JOIN ? asks the driver which network is associated, which it reports when
+\ the parameter block is empty.
+.query_network      lda #0
+                    sta heap
+
+.join_network       ldx #>heap
+                    ldy #<heap
+                    lda #&04
+                    jmp generic_cmd
+
+.leave_cmd          lda #&05
+                    jmp generic_cmd

--- a/beeb/1mhz-wifi/src/lap.asm
+++ b/beeb/1mhz-wifi/src/lap.asm
@@ -1,0 +1,38 @@
+\ lap.asm
+\ 1MHz-WiFi ROM: *LAP and *LAPOPT.
+\
+\ Written for the 1MHz-WiFi project, replacing the inherited version.
+\
+\   *LAP            list the access points the Pi can see
+\   *LAPOPT [n]     set the scan options, defaulting to 127
+\
+\ Both are driver calls whose reply the driver prints, so there is nothing to
+\ do here beyond preparing the parameter block.
+
+.lap_cmd            lda #3
+                    jmp generic_cmd
+
+.lapopt_cmd         jsr skipspace1
+                    jsr read_cli_param
+                    cpx #&00
+                    bne lapopt_param
+
+\ No option given: put the default of 127 in the parameter block as the digits
+\ the driver expects, terminated with a carriage return.
+                    lda #'1'
+                    sta heap
+                    lda #'2'
+                    sta heap+1
+                    lda #'7'
+                    sta heap+2
+                    lda #&0D
+                    sta heap+3
+                    bne do_lapopt               \ always taken, A is not zero
+
+.lapopt_param       ldx #0
+                    jsr copy_to_heap
+
+.do_lapopt          ldx #>heap
+                    ldy #<heap
+                    lda #25
+                    jmp generic_cmd

--- a/beeb/1mhz-wifi/src/machine.asm
+++ b/beeb/1mhz-wifi/src/machine.asm
@@ -1,0 +1,128 @@
+\ machine.asm
+\ 1MHz-WiFi ROM: machine definitions, MOS entry points and workspace layout.
+\
+\ Written for the 1MHz-WiFi project. This file replaces the equate header the
+\ ROM inherited from ElkWiFi 0.23. Nothing here is copied from it: the MOS
+\ entry addresses and the AP5 register addresses are properties of the machine
+\ and of the Pi1MHz hardware, and the workspace assignments below are the ones
+\ this ROM's own code needs. The values that must agree with something else are
+\ marked as such, because those are the ones that cannot be moved freely.
+
+\ ---------------------------------------------------------------------------
+\ Target selection
+\ ---------------------------------------------------------------------------
+\ The ROM is built once and runs on both machine families. __ELECTRON__ selects
+\ the code paths that differ; it is not a claim about which machine is present,
+\ which is decided at run time through OSBYTE &81.
+
+            __ELECTRON__ = 1
+
+\ ---------------------------------------------------------------------------
+\ MOS entry points (Acorn published interface)
+\ ---------------------------------------------------------------------------
+
+            osrdch = &FFE0
+            osasci = &FFE3
+            osnewl = &FFE7
+            oswrch = &FFEE
+            osbyte = &FFF4
+            oscli  = &FFF7
+            OSWORD = &FFF1
+            OSFSC  = &FFE9
+            \ Some sources spell these in capitals; both name the same entry.
+            OSASCI = &FFE3
+            OSWRCH = &FFEE
+            OSBYTE = &FFF4
+            OSRDCH = &FFE0
+
+\ MOS vectors the filing system ROM claims. Listed here so both images agree
+\ on them and neither depends on the other's header.
+
+            OSFILEV = &0212         \ OSFILE
+            OSBGETV = &0216         \ OSBGET, sequential read
+            OSFINDV = &021C         \ OSFIND, open
+            OSFSCV  = &021E         \ filing system control
+            BYTEV   = &020A         \ OSBYTE
+
+\ ---------------------------------------------------------------------------
+\ 1MHz bus / AP5 interface
+\ ---------------------------------------------------------------------------
+\ The service cursor at &FCA6-&FCAA and the JIM window are the whole of this
+\ ROM's transport. The cartridge UART the original hardware used at &FC30 is
+\ deliberately not defined here: nothing in this ROM may reach for it.
+
+            pagereg = &FCFF         \ AP5-visible JIM page selector, write only
+            pageram = &FD00         \ JIM page data window, 256 bytes
+
+\ ---------------------------------------------------------------------------
+\ Zero page
+\ ---------------------------------------------------------------------------
+\ &B0-&BF is the sideways-ROM scratch the MOS leaves to the active ROM, and
+\ &F2/&F3 is the MOS command-line pointer. Offsets inside the &B0 block are
+\ grouped by the routine that owns them; several deliberately overlap, because
+\ the block is only sixteen bytes and no two overlapping users are ever live at
+\ the same time.
+
+            line = &F2              \ MOS command line pointer (OS defined)
+            zp   = &B0              \ base of this ROM's zero page block
+
+            \ General scratch. Owned by whichever routine is running; the
+            \ driver saves the caller's registers here across a Pi request.
+            save_a = zp+2
+            save_y = zp+3
+            save_x = zp+4
+
+            \ The OSWORD &65 parameter block pointer shares save_y: the driver
+            \ has finished with the saved Y by the time it needs the pointer.
+            paramblok = save_y
+
+            \ Transfer sizes and addresses.
+            data_counter = zp+6
+            load_addr    = zp+9
+
+            \ Buffer walk. buffer_ptr and data_pointer must stay adjacent so a
+            \ sixteen bit pointer can be incremented across the pair.
+            data_pointer = zp+11
+            size         = zp+11    \ search length, shares data_pointer
+            needle       = zp+12    \ search string pointer, 2 bytes
+            datalen      = zp+13    \ remaining data length, 2 bytes
+
+            \ The UEF stream handover to the filing system ROM. *WGET -U
+            \ downloads an image into the JIM window and records its length
+            \ and cursor here; the filing system ROM reads them to stream the
+            \ image out. These four addresses are the whole of the contract
+            \ between the two ROMs, alongside the JIM window itself, so they
+            \ must agree with the filing system ROM's own definitions.
+            sbufl = &F8             \ stream bytes remaining, low
+            sbufh = &F9             \ stream bytes remaining, high
+            pr_y  = &C7             \ stream cursor offset within the page
+            pr_r  = &C8             \ stream cursor page register shadow
+
+            \ Connection state read by the public OSWORD &65 driver.
+            mux_status  = &90
+
+\ ---------------------------------------------------------------------------
+\ Main memory workspace
+\ ---------------------------------------------------------------------------
+\ These are volatile scratch areas below PAGE. Each is used only for the span
+\ of one command, so the overlaps below are safe and are documented where they
+\ are not obvious.
+
+            heap       = &900       \ command parameter block
+            strbuf     = &A00       \ command line parameter string
+
+            \ Retired network printer workspace. The printer support this ROM
+            \ inherited has been removed, so the bytes are free; the dynamic
+            \ error block is built here rather than on the &0100 stack.
+            netprt = &D90           \ 32 bytes
+
+            \ The ROM select register is not the same on every target, so it
+            \ is not equated here: &FE05 with the Electron deselect cycle
+            \ against &FE30 on the BBC family, chosen at run time from
+            \ driver_machine. shadow is the MOS copy of the selected ROM
+            \ number, which is &F4 on all four machines.
+            shadow = &F4
+
+\ The image carries the ATM header the loader expects ahead of the ROM itself.
+
+ORG &8000-22

--- a/beeb/1mhz-wifi/src/mode.asm
+++ b/beeb/1mhz-wifi/src/mode.asm
@@ -1,0 +1,34 @@
+\ mode.asm
+\ 1MHz-WiFi ROM: *MODE.
+\
+\ Written for the 1MHz-WiFi project, replacing the inherited version.
+\
+\   *MODE 1         station mode
+\   *MODE ?         report the current mode
+\
+\ The inherited ROM offered access point and combined modes as well. Pi1MHz
+\ associates as a station only, so those are not offered and the usage text
+\ lists what the hardware will actually do.
+
+.mode_cmd           jsr skipspace1
+                    jsr read_cli_param
+                    cpx #&00
+                    bne mode_init_heap
+                    jsr printtext
+                    equs "Usage: *MODE <1|?>",&0D
+                    equs "MODE 1 -> STATION",&0D
+                    equb &EA
+                    jmp call_claimed
+
+.mode_init_heap     ldx #0
+                    jsr copy_to_heap
+                    lda heap
+                    cmp #'?'
+                    bne set_mode
+                    lda #0                      \ an empty block is the query
+                    sta heap
+
+.set_mode           ldx #>heap
+                    ldy #<heap
+                    lda #&07
+                    jmp generic_cmd

--- a/beeb/1mhz-wifi/src/net_transport.asm
+++ b/beeb/1mhz-wifi/src/net_transport.asm
@@ -1,0 +1,187 @@
+\ net_transport.asm
+\ Pi1MHz service transport: addressing, byte access and dispatch.
+\
+\ Written for the 1MHz-WiFi project. This is the layer both ROMs talk to the
+\ Pi through, so it lives in its own file rather than inside *WGET, which is
+\ where it happened to be written first. The network ROM uses it for every
+\ command; the filing system ROM uses it to read persisted state and to fetch
+\ UEF windows.
+\
+\ The service registers are at &FC00+net_svc_*, and a cursor is held across
+\ calls so a caller can address once and then read or write a run of bytes.
+
+net_result_pending = 1
+net_wait_lo = heap+&EA
+net_wait_hi = heap+&EB
+net_svc_addr_lo = &A6
+net_svc_addr_mid = &A7
+net_svc_addr_hi = &A8
+net_svc_data = &A9
+net_svc_command = &AA
+net_empty_lo = drv_svc_workspace+24
+net_empty_hi = drv_svc_workspace+25
+net_cursor_lo = drv_svc_workspace+21
+net_cursor_mid = drv_svc_workspace+22
+net_cursor_hi = drv_svc_workspace+23
+
+\ Select logical JIM &FFF000: Pi1MHz maps it into the reserved service RAM.
+.net_command_address
+ lda #0
+ jsr net_address_low
+ lda #&F0
+ jsr net_address_mid
+ lda #&FF
+ jmp net_address_high
+
+.net_scratch_address
+ lda #0
+ jsr net_address_low
+ lda #&F1
+ jsr net_address_mid
+ lda #&FF
+ jmp net_address_high
+
+.net_address_low
+ sta net_cursor_lo
+ sta &FC00+net_svc_addr_lo
+ jsr bus_delay
+ rts
+.net_address_mid
+ sta net_cursor_mid
+ sta &FC00+net_svc_addr_mid
+ jsr bus_delay
+ rts
+.net_address_high
+ sta net_cursor_hi
+ sta &FC00+net_svc_addr_hi
+ jsr bus_delay
+ rts
+
+.net_write_a
+ php
+ sei
+ pha
+ lda net_cursor_lo
+ sta &FC00+net_svc_addr_lo
+ jsr bus_delay
+ lda net_cursor_mid
+ sta &FC00+net_svc_addr_mid
+ jsr bus_delay
+ lda net_cursor_hi
+ sta &FC00+net_svc_addr_hi
+ jsr bus_delay
+ pla
+ sta &FC00+net_svc_data
+ jsr bus_delay
+ inc net_cursor_lo
+ bne net_write_done
+ inc net_cursor_mid
+ bne net_write_done
+ inc net_cursor_hi
+.net_write_done
+ jsr net_wait_cursor
+ plp
+ rts
+
+.net_read_a
+ php
+ sei
+ lda net_cursor_lo
+ sta &FC00+net_svc_addr_lo
+ jsr bus_delay
+ lda net_cursor_mid
+ sta &FC00+net_svc_addr_mid
+ jsr bus_delay
+ lda net_cursor_hi
+ sta &FC00+net_svc_addr_hi
+ jsr bus_delay
+ lda &FC00+net_svc_data
+ jsr bus_delay
+ pha
+ inc net_cursor_lo
+ bne net_read_done
+ inc net_cursor_mid
+ bne net_read_done
+ inc net_cursor_hi
+.net_read_done
+ jsr net_wait_cursor
+ pla
+ plp
+ cmp #0
+ rts
+
+\ FCA9 read/write callbacks advance the shared cursor asynchronously on real
+\ Pi1MHz hardware. Wait until the complete published cursor matches the
+\ software cursor before another transaction can select FCA6-FCA8. The loop is
+\ deliberately bounded and preserves A and X.
+.net_wait_cursor
+ pha
+ txa
+ pha
+ ldx #0
+.net_wait_cursor_loop
+ lda &FC00+net_svc_addr_lo
+ jsr bus_delay
+ cmp net_cursor_lo
+ bne net_wait_cursor_again
+ lda &FC00+net_svc_addr_mid
+ jsr bus_delay
+ cmp net_cursor_mid
+ bne net_wait_cursor_again
+ lda &FC00+net_svc_addr_hi
+ jsr bus_delay
+ cmp net_cursor_hi
+ beq net_wait_cursor_done
+.net_wait_cursor_again
+ dex
+ bne net_wait_cursor_loop
+.net_wait_cursor_done
+ pla
+ tax
+ pla
+ rts
+
+\ Dispatch handle zero (&F0).  Bit 7 means the Pi main loop has not serviced
+\ the FIQ latch; result 1 means an async DNS/connect is still pending and must
+\ be re-issued.  Both paths are bounded and Escape-aware.
+.net_dispatch_wait
+ lda #0
+ sta net_wait_lo
+ lda #&FF                 \ about five seconds at one yield per video frame
+ sta net_wait_hi
+.net_dispatch_again
+ php
+ sei
+ lda #&F0
+ sta &FC00+net_svc_command
+ jsr bus_delay
+ plp
+.net_dispatch_busy
+ lda &FC00+net_svc_command
+ bpl net_dispatch_ready
+ dec net_wait_lo
+ bne net_dispatch_busy
+ lda #19                  \ yield to the Pi main-loop network poll
+ jsr osbyte
+ dec net_wait_hi
+ bne net_dispatch_busy
+ jmp net_dispatch_timeout
+.net_dispatch_ready
+ cmp #net_result_pending
+ bne net_dispatch_return
+ jsr check_esc
+ bcs net_dispatch_cancel
+ lda #19
+ jsr osbyte
+ dec net_wait_lo
+ bne net_dispatch_again
+ dec net_wait_hi
+ bne net_dispatch_again
+ jmp net_dispatch_timeout
+.net_dispatch_cancel
+ lda #&2A                  \ cancelled: never masquerade as successful EOF
+.net_dispatch_return
+ rts
+.net_dispatch_timeout
+ lda #&29                  \ private transport-timeout result
+ rts

--- a/beeb/1mhz-wifi/src/net_wget.asm
+++ b/beeb/1mhz-wifi/src/net_wget.asm
@@ -1,0 +1,646 @@
+\ Pi1MHz-native WGET transport.
+\
+\ The original ElkWiFi command talks to its 16C2552 at &FC30.  That address
+\ is not forwarded by the AP5 and is unsafe from a Tube parasite.  This
+\ implementation uses Pi1MHz's URL service through the FCA6 mailbox and
+\ accesses the AP5-forwarded FRED services window from the I/O processor.
+
+
+net_cmd_url_open = 60
+net_cmd_url_read = 61
+net_cmd_url_close = 63
+net_cmd_url_status = 64
+net_result_eof = &20
+net_result_http_status = &30
+net_result_unsupported = &27
+net_cmd_copy_public = 58
+
+wget_OSFIND = &FFCE
+wget_OSBPUT = &FFD4
+
+net_count = heap+&E8
+net_cli_y = heap+&E9
+\ The raw ElkWiFi OSWORD receive path shares these counters and the cursor
+\ helpers below. They must not occupy the &0900 ADFS/application workspace.
+net_result = heap+&EE
+net_transfer_ok = heap+&EF
+net_received = heap+&F0
+net_bytes_lo = heap+&F3
+net_bytes_hi = heap+&F4
+net_paged_page = heap+&E4
+net_paged_offset = heap+&E5
+\ heap+&E6 belongs to the host BASIC transition workspace. Use &E7.
+net_primary_page = heap+&E7
+net_file_handle = heap+&E0
+net_file_mode = heap+&E1
+net_bytes_bank = heap+&E2
+\ heap+&E3 and &E7 are otherwise unused across the whole ROM build.
+\ &F5-&F7 collide with wget.asm's proto/newln/clptr, and &E6 belongs to the
+\ host BASIC transition workspace. Both share the same "heap" workspace.
+
+\ Close the ElkWiFi-compatible raw socket and display the Pi response. The
+\ inherited wget_close routine is also an internal silent cleanup path.
+.disconnect_cmd
+ lda #14
+ jmp generic_cmd
+
+.pi_wget_cmd
+ jsr detect_jim_machine
+ lda #0
+ sta net_transfer_ok
+ sta net_received
+ sta net_bytes_lo
+ sta net_bytes_hi
+ sta net_paged_page
+ sta net_paged_offset
+ sta net_primary_page
+ sta net_file_handle
+ sta net_file_mode
+ sta net_bytes_bank
+ sta tflag
+ sta sflag
+ sta aflag
+ sta pflag
+ sta uflag
+ sta proto
+ sta load_addr
+ sta load_addr+1
+ sta laddr
+ sta laddr+1
+ lda #&0D
+ sta newln
+
+.pi_wget_param
+ jsr skipspace1
+ jsr read_cli_param
+ cpx #0
+ bne pi_wget_have_param
+ jmp pi_wget_usage
+
+.pi_wget_have_param
+ lda strbuf
+ cmp #'-'
+ bne pi_wget_url
+ lda strbuf+1
+ ora #&20
+ cmp #'t'
+ beq pi_wget_text
+ cmp #'x'
+ beq pi_wget_unix_text
+ cmp #'u'
+ beq pi_wget_uef
+ cmp #'s'
+ beq pi_wget_sideways
+ \ Container formats still use the original decoder, which requires the
+ \ cartridge UART.  Fail explicitly instead of touching &FC30 on AP5/Tube.
+ ldx #(error_not_implemented-error_table)
+ jmp error
+
+.pi_wget_uef
+ lda #1
+ sta uflag
+ bne pi_wget_param
+
+.pi_wget_sideways
+ lda #1
+ sta sflag
+ bne pi_wget_param
+
+.pi_wget_unix_text
+ lda #&0A
+ sta newln
+.pi_wget_text
+ lda #1
+ sta tflag
+ jmp pi_wget_param
+
+.pi_wget_url
+ \ Preserve the MOS command-line index while building the service request.
+ sty net_cli_y
+ jsr net_command_address
+ lda #net_cmd_url_open
+ jsr net_write_a
+ lda #4                    \ NET_OPEN_READ
+ jsr net_write_a
+ ldx #0
+.pi_wget_url_copy
+ stx net_count
+ lda strbuf,x
+ cmp #&0D
+ bne pi_wget_url_char
+ lda #0
+.pi_wget_url_char
+ jsr net_write_a
+ cmp #0
+ beq pi_wget_url_done
+ ldx net_count
+ inx
+ bne pi_wget_url_copy
+ ldx #(error_bad_param-error_table)
+ jmp error
+
+.pi_wget_url_done
+ \ Ordinary WGET writes a named file through the active MOS filing system.
+ \ Text mode needs no destination, -U owns the public JIM window, and -S uses
+ \ its final parameter as the sideways RAM slot number.
+ ldy net_cli_y
+ jsr skipspace1
+ jsr read_cli_param
+ lda tflag
+ bne pi_wget_address_ok
+ lda uflag
+ bne pi_wget_address_ok
+ lda sflag
+ bne pi_wget_parse_slot
+ cpx #0
+ bne pi_wget_file_name
+ jmp pi_wget_usage
+.pi_wget_file_name
+ lda #&FF
+ sta net_file_mode
+ jmp pi_wget_address_ok
+.pi_wget_parse_slot
+ cpx #0
+ bne pi_wget_have_slot
+ jmp pi_wget_usage
+.pi_wget_have_slot
+ ldx #load_addr
+ jsr string2hex
+ sta net_result
+ lda load_addr
+ sta laddr
+ lda load_addr+1
+ sta laddr+1
+.pi_wget_address_ok
+.pi_wget_address_ready
+ jsr net_dispatch_wait
+ cmp #0
+ beq pi_wget_opened
+ jsr pi_wget_network_error
+
+.pi_wget_opened
+ lda net_file_mode
+ beq pi_wget_output_ready
+ lda #&80                  \ open output file through the current filing system
+ ldx #<strbuf
+ ldy #>strbuf
+ jsr wget_OSFIND
+ sta net_file_handle
+ bne pi_wget_output_ready
+ jsr pi_wget_close
+ jsr printtext
+ equs "Cannot create file",&0D,&EA
+ jmp call_claimed
+.pi_wget_output_ready
+ lda #0
+ sta net_empty_lo
+ sta pr_r
+ sta pr_y
+ sta sbufl
+ sta sbufh
+ lda #10
+ sta net_empty_hi
+
+.pi_wget_read
+ jsr net_command_address
+ lda #net_cmd_url_read
+ jsr net_write_a
+ lda #240                  \ maximum bytes in the scratch page
+ jsr net_write_a
+ lda #0
+ jsr net_write_a
+ jsr net_write_a
+ lda #0                    \ JIM offset &00FFF100, little endian
+ jsr net_write_a
+ lda #&F1
+ jsr net_write_a
+ lda #&FF
+ jsr net_write_a
+ lda #0
+ jsr net_write_a
+ jsr net_dispatch_wait
+ cmp #net_result_eof
+ bne pi_wget_not_eof
+ jmp pi_wget_done
+.pi_wget_not_eof
+ cmp #0
+ beq pi_wget_read_length
+ jsr pi_wget_network_error
+
+.pi_wget_read_length
+ jsr net_command_address
+ lda #1
+ jsr net_address_low
+ jsr net_read_a
+ sta net_count
+ bne pi_wget_have_bytes
+ jmp pi_wget_empty
+.pi_wget_have_bytes
+ lda #0
+ sta net_empty_lo
+ lda #10
+ sta net_empty_hi
+ lda tflag
+ bne pi_wget_copy_legacy
+ lda uflag
+ ora sflag
+ beq pi_wget_copy_legacy
+ \ Raw paged transfers are already in the Pi service scratch page. Copy the
+ \ complete chunk to its final public JIM address in one Pi-side operation.
+ \ This avoids both a host byte loop and the unsafe page-&FF staging alias.
+ clc
+ lda net_paged_offset
+ adc net_count
+ lda net_paged_page
+ adc #0
+ bcc pi_wget_copy_paged_bulk
+ jsr pi_wget_close
+ ldx #(error_buffer_full-error_table)
+ jmp error
+.pi_wget_copy_paged_bulk
+ jsr net_command_address
+ lda #net_cmd_copy_public
+ jsr net_write_a
+ lda net_count
+ jsr net_write_a
+ lda net_paged_offset
+ jsr net_write_a
+ lda net_paged_page
+ jsr net_write_a
+ jsr net_dispatch_wait
+ cmp #0
+ bne pi_wget_copy_paged_not_ok
+ jmp pi_wget_copy_paged_advance
+.pi_wget_copy_paged_not_ok
+ cmp #net_result_unsupported
+ bne pi_wget_copy_paged_error
+ \ A previous Pi1MHz kernel has no command 58. Retain the original safe,
+ \ byte-at-a-time path so ROM and kernel updates need not be atomic.
+.pi_wget_copy_legacy
+ jsr net_scratch_address
+
+.pi_wget_copy
+ jsr net_read_a
+ ldx tflag
+ beq pi_wget_store
+ cmp newln
+ bne pi_wget_print
+ lda #&0D
+.pi_wget_print
+ jsr osasci
+ jmp pi_wget_copied
+.pi_wget_store
+ pha
+ lda net_file_mode
+ bne pi_wget_store_file
+ pla
+ jsr pi_wget_store_paged
+ jmp pi_wget_copied
+.pi_wget_store_file
+ pla
+ ldy net_file_handle
+ jsr wget_OSBPUT
+ jmp pi_wget_copied
+.pi_wget_copied
+ lda #&FF
+ sta net_received
+ inc net_bytes_lo
+ bne pi_wget_counted
+ inc net_bytes_hi
+ bne pi_wget_counted
+ inc net_bytes_bank
+.pi_wget_counted
+ dec net_count
+ bne pi_wget_copy
+ jsr check_esc
+ bcs pi_wget_copy_cancel
+ jmp pi_wget_read
+.pi_wget_copy_paged_error
+ jsr pi_wget_network_error
+.pi_wget_copy_paged_advance
+ lda #&FF
+ sta net_received
+ clc
+ lda net_paged_offset
+ adc net_count
+ sta net_paged_offset
+ lda net_paged_page
+ adc #0
+ sta net_paged_page
+ clc
+ lda net_bytes_lo
+ adc net_count
+ sta net_bytes_lo
+ lda net_bytes_hi
+ adc #0
+ sta net_bytes_hi
+ jsr check_esc
+ bcs pi_wget_copy_cancel
+ jmp pi_wget_read
+.pi_wget_copy_cancel
+ jsr pi_wget_close
+ jmp call_claimed
+
+.pi_wget_empty
+ \ An open HTTP stream may legitimately have no bytes yet.  Allow roughly
+ \ 50 seconds without progress, while still honouring Escape.
+ jsr check_esc
+ bcc pi_wget_empty_wait
+ jmp pi_wget_copy_cancel
+.pi_wget_empty_wait
+ lda #19
+ jsr osbyte
+ dec net_empty_lo
+ beq pi_wget_empty_high
+ jmp pi_wget_read
+.pi_wget_empty_high
+ dec net_empty_hi
+ beq pi_wget_empty_timeout
+ jmp pi_wget_read
+.pi_wget_empty_timeout
+ jsr pi_wget_timeout
+
+.pi_wget_done
+ lda net_received
+ bne pi_wget_has_response
+ jmp pi_wget_empty_response
+.pi_wget_has_response
+ lda #&FF
+ sta net_transfer_ok
+ lda uflag
+ ora sflag
+ bne pi_wget_paged_finish
+ jmp pi_wget_finish_close
+.pi_wget_paged_finish
+ lda #0
+ sta pr_r
+ sta pr_y
+ lda net_bytes_lo
+ sta sbufl
+ lda net_bytes_hi
+ sta sbufh
+ php
+ sei
+ jsr set_bank_1
+ lda #&FF
+ sta pagereg
+ jsr bus_delay
+ lda net_bytes_lo
+ sta &FDFE
+ jsr bus_delay
+ lda net_bytes_hi
+ sta &FDFF
+ jsr bus_delay
+ plp
+ lda uflag
+ beq pi_wget_normalized
+ \ ElkWiFi -U means "store in paged RAM"; it does not promise that the
+ \ payload is a UEF. Only ask the Pi to expand inputs carrying a gzip or ZIP
+ \ signature; ordinary raw paged-RAM downloads must remain byte-exact.
+ \ This also keeps ordinary -U transfers compatible with kernels predating
+ \ the optional normalisation service.
+ lda #'R'
+ sta net_result
+ php
+ sei
+ lda #0
+ sta pagereg
+ jsr bus_delay
+ lda pageram
+ sta zp
+ lda pageram+1
+ sta zp+1
+ plp
+ lda zp
+ cmp #&1F
+ bne pi_wget_check_zip
+ lda zp+1
+ cmp #&8B
+ beq pi_wget_normalize_compressed
+.pi_wget_check_zip
+ lda zp
+ cmp #'P'
+ bne pi_wget_raw_paged
+ lda zp+1
+ cmp #'K'
+ bne pi_wget_raw_paged
+.pi_wget_normalize_compressed
+ jsr service_driver_uef_normalize
+ cmp #'I'
+ bne pi_wget_not_invalid_uef
+ jsr pi_wget_close
+ jsr set_bank_0
+ jmp pi_wget_invalid_uef
+.pi_wget_not_invalid_uef
+ cmp #'T'
+ bne pi_wget_normalize_ok
+ jsr pi_wget_close
+ jsr set_bank_0
+ jmp pi_wget_too_large
+.pi_wget_normalize_ok
+ sta net_result
+ \ Command 93 rewrites the authoritative trailer with the expanded length.
+ php
+ sei
+ jsr set_bank_1
+ lda #&FF
+ sta pagereg
+ jsr bus_delay
+ lda &FDFE
+ sta net_bytes_lo
+ sta sbufl
+ lda &FDFF
+ sta net_bytes_hi
+ sta sbufh
+ plp
+ jmp pi_wget_normalized
+.pi_wget_raw_paged
+ php
+ sei
+ lda #&FF
+ sta pagereg
+ jsr bus_delay
+ plp
+.pi_wget_normalized
+ php
+ sei
+ jsr set_bank_0
+ lda net_primary_page
+ sta pagereg
+ jsr bus_delay
+ plp
+ lda sflag
+ beq pi_wget_finish_close
+ jsr wget_copy_file_to_swr
+.pi_wget_finish_close
+ jsr pi_wget_close
+ jsr printtext
+ equs "WGET ",&EA
+ lda uflag
+ beq pi_wget_report_format_done
+ lda net_result
+ cmp #'G'
+ bne pi_wget_report_zip
+ jsr printtext
+ equs "GZIP ",&EA
+ jmp pi_wget_report_format_done
+.pi_wget_report_zip
+ cmp #'Z'
+ bne pi_wget_report_raw
+ jsr printtext
+ equs "ZIP ",&EA
+ jmp pi_wget_report_format_done
+.pi_wget_report_raw
+ jsr printtext
+ equs "RAW ",&EA
+.pi_wget_report_format_done
+ jsr printtext
+ equs "OK &",&EA
+ lda net_file_mode
+ beq pi_wget_report_16bit_size
+ lda net_bytes_bank
+ jsr printhex
+.pi_wget_report_16bit_size
+ lda net_bytes_hi
+ jsr printhex
+ lda net_bytes_lo
+ jsr printhex
+ jsr printtext
+ equs " bytes",&EA
+ lda tflag
+ bne pi_wget_report_end
+ lda net_file_mode
+ bne pi_wget_report_file
+ jmp pi_wget_report_jim
+.pi_wget_report_file
+ jsr printtext
+ equs " saved",&EA
+ jmp pi_wget_report_end
+.pi_wget_report_jim
+ jsr printtext
+ equs " in JIM",&EA
+.pi_wget_report_end
+ jsr osnewl
+ jmp call_claimed
+
+.pi_wget_empty_response
+ jsr printtext
+ equs "Empty response",&0D,&EA
+ jmp pi_wget_close_claimed
+
+.pi_wget_store_paged
+ php
+ sei                         \ FCFF and the JIM aperture are shared by AP5 users
+ pha
+ jsr set_bank_1
+ lda net_paged_page
+ sta pagereg
+ jsr bus_delay
+ ldy net_paged_offset
+ pla
+ sta pageram,y
+ jsr bus_delay
+ iny
+ bne pi_wget_paged_pointer_ok
+ inc net_paged_page
+ beq pi_wget_paged_full
+ lda net_paged_page
+ sta pagereg
+ jsr bus_delay
+.pi_wget_paged_pointer_ok
+ sty net_paged_offset
+ jsr set_bank_0
+ lda net_primary_page
+ sta pagereg
+ jsr bus_delay
+ plp
+ rts
+.pi_wget_paged_full
+ jsr set_bank_0
+ lda net_primary_page
+ sta pagereg
+ jsr bus_delay
+ plp
+ jsr pi_wget_close
+ ldx #(error_buffer_full-error_table)
+ jmp error
+
+.pi_wget_close
+ pha
+ lda net_file_handle
+ beq pi_wget_file_closed
+ tay
+ lda #0
+ sta net_file_handle
+ jsr wget_OSFIND
+.pi_wget_file_closed
+ pla
+ jsr net_command_address
+ lda #net_cmd_url_close
+ jsr net_write_a
+ jsr net_dispatch_wait
+ rts
+
+.pi_wget_usage
+ jsr printtext
+ equs "Usage: WGET <url> <file>",&0D
+ equs "       WGET [-TXUS] <url> [slot]",&0D,&EA
+ jmp call_claimed
+
+.pi_wget_timeout
+ jsr printtext
+ equs "Network timeout",&0D,&EA
+ jmp pi_wget_close_claimed
+
+.pi_wget_network_error
+ jsr print_network_error
+ lda net_result
+ cmp #net_result_http_status
+ bne pi_wget_close_claimed
+ \ Preserve the server's actual HTTP status before URL_CLOSE clears the
+ \ handle.  Error &30 alone cannot distinguish a redirect or rejection from
+ \ a malformed/corrupted response on physical Pi1MHz hardware.
+ jsr net_command_address
+ lda #net_cmd_url_status
+ jsr net_write_a
+ jsr net_dispatch_wait
+ cmp #0
+ bne pi_wget_close_claimed
+ lda #7
+ jsr net_address_low
+ jsr net_read_a
+ sta load_addr
+ jsr net_read_a
+ sta load_addr+1
+ jsr printtext
+ equs "HTTP status &",&EA
+ lda load_addr+1
+ jsr printhex
+ lda load_addr
+ jsr printhex
+ jsr osnewl
+.pi_wget_close_claimed
+ jsr pi_wget_close
+ jmp call_claimed
+
+.print_network_error
+ sta net_result
+ jsr printtext
+ equs "Network error &",&EA
+ lda net_result
+ jsr printhex
+ jmp osnewl
+
+\ The Pi normaliser rejected the downloaded image, or it will not fit in the
+\ JIM window. *WGET -U reports that itself: the filing system ROM is a
+\ separate image and may not even be fitted.
+
+.pi_wget_invalid_uef
+ jsr printtext
+ equs "Invalid UEF, gzip or ZIP file",&0D,&EA
+ jmp call_claimed
+
+.pi_wget_too_large
+ jsr printtext
+ equs "Expanded UEF exceeds &FFFE bytes",&0D,&EA
+ jmp call_claimed

--- a/beeb/1mhz-wifi/src/nslook.asm
+++ b/beeb/1mhz-wifi/src/nslook.asm
@@ -1,0 +1,136 @@
+\ Resident IPv4 resolver using the same Pi1MHz mailbox transport as WGET.
+
+nslook_octet = heap+&B2
+nslook_index = heap+&B3
+nslook_address = heap+&B4
+
+.nslook_cmd
+ jsr skipspace1
+ jsr read_cli_param
+ cpx #0
+ bne nslook_have_host
+ jsr printtext
+ equs "Usage: *NSLOOK <hostname>",&0D,&EA
+ jmp call_claimed
+
+.nslook_have_host
+ jsr net_command_address
+ lda #45                    \ NET_CMD_OPEN
+ jsr net_write_a
+ lda #0                     \ NET_TYPE_TCP
+ jsr net_write_a
+ jsr net_dispatch_wait
+ cmp #0
+ bne nslook_error
+
+ jsr net_command_address
+ lda #46                    \ NET_CMD_DNS
+ jsr net_write_a
+ ldx #0
+.nslook_copy_host
+ stx nslook_index
+ lda strbuf,x
+ cmp #&0D
+ bne nslook_write_host
+ lda #0
+.nslook_write_host
+ jsr net_write_a
+ cmp #0
+ beq nslook_resolve
+ ldx nslook_index
+ inx
+ bne nslook_copy_host
+ lda #&2B
+ bne nslook_error_close
+
+.nslook_resolve
+ jsr net_dispatch_wait
+ cmp #0
+ bne nslook_error_close
+ jsr net_command_address
+ lda #4
+ jsr net_address_low
+ ldx #0
+.nslook_copy_ip
+ jsr net_read_a
+ sta nslook_address,x
+ inx
+ cpx #4
+ bne nslook_copy_ip
+
+ jsr printtext
+ equs "Address: ",&EA
+ ldx #0
+.nslook_print_ip
+ stx nslook_octet
+ lda nslook_address,x
+ jsr nslook_print_u8
+ ldx nslook_octet
+ inx
+ cpx #4
+ beq nslook_done
+ lda #'.'
+ jsr oswrch
+ jmp nslook_print_ip
+.nslook_done
+ jsr osnewl
+ jsr nslook_close
+ jmp call_claimed
+
+.nslook_error_close
+ pha
+ jsr nslook_close
+ pla
+.nslook_error
+ jsr print_network_error
+ jmp call_claimed
+
+.nslook_close
+ jsr net_command_address
+ lda #53                    \ NET_CMD_CLOSE
+ jsr net_write_a
+ jsr net_dispatch_wait
+ rts
+
+.nslook_print_u8
+ ldx #'0'
+.nslook_hundreds
+ cmp #100
+ bcc nslook_hundreds_done
+ sec
+ sbc #100
+ inx
+ bne nslook_hundreds
+.nslook_hundreds_done
+ pha
+ cpx #'0'
+ beq nslook_tens_start
+ txa
+ jsr oswrch
+ pla
+ pha
+ ldx #':'                   \ force a zero tens digit when needed
+.nslook_tens_start
+ pla
+ ldy #'0'
+.nslook_tens
+ cmp #10
+ bcc nslook_tens_done
+ sec
+ sbc #10
+ iny
+ bne nslook_tens
+.nslook_tens_done
+ pha
+ cpx #'0'
+ bne nslook_show_tens
+ cpy #'0'
+ beq nslook_ones
+.nslook_show_tens
+ tya
+ jsr oswrch
+.nslook_ones
+ pla
+ clc
+ adc #'0'
+ jmp oswrch

--- a/beeb/1mhz-wifi/src/online.asm
+++ b/beeb/1mhz-wifi/src/online.asm
@@ -1,0 +1,6 @@
+\ One-line network readiness check.
+\ Syntax: *ONLINE
+
+.online_cmd
+ jsr service_driver_online
+ jmp generic_response

--- a/beeb/1mhz-wifi/src/pdump.asm
+++ b/beeb/1mhz-wifi/src/pdump.asm
@@ -1,0 +1,126 @@
+; PRD - inspect Pi1MHz JIM without reading the write-only selectors.
+;
+; Syntax: *PRD [address] [bank]
+;
+; `address` is a 16-bit offset in the selected 64K window. Direct BBC-family
+; connections expose bank 0/1 through &FCFE. Electron AP5 only forwards the
+; page selector, so bank 1 is rejected instead of being silently ignored.
+
+pdump_bank = driver_entry_x
+
+.pdump_cmd
+ jsr detect_jim_machine
+ lda #0
+ sta pdump_bank
+ sta load_addr
+ sta load_addr+1
+ jsr skipspace1
+ jsr read_cli_param
+ cpx #0
+ beq pdump_start
+ ldx #load_addr
+ jsr string2hex
+
+ jsr skipspace1
+ jsr read_cli_param
+ cpx #0
+ beq pdump_start
+ ldx #zp
+ jsr string2hex
+ lda zp+1
+ bne pdump_bad_bank
+ lda zp
+ cmp #2
+ bcs pdump_bad_bank
+ sta pdump_bank
+ beq pdump_start
+ lda driver_machine
+ cmp #1
+ bne pdump_start
+ jmp pdump_bad_bank
+
+.pdump_bad_bank
+ jsr set_bank_0
+ ldx #(error_bad_option-error_table)
+ jmp error
+
+.pdump_start
+ lda load_addr
+ and #&F8
+ sta load_addr
+ tay
+
+.pdump_l1
+ lda load_addr+1
+ jsr printhex
+ lda #':'
+ jsr oswrch
+ tya
+ pha
+ jsr printhex
+ lda #' '
+ jsr oswrch
+ jsr oswrch
+ ldx #8
+.pdump_l2
+ jsr pdump_read_y
+ jsr printhex
+ lda #' '
+ jsr oswrch
+ iny
+ dex
+ bne pdump_l2
+ pla
+ tay
+ ldx #8
+.pdump_l3
+ jsr pdump_read_y
+ bmi pdump_dot
+ cmp #&20
+ bmi pdump_dot
+ cmp #&7F
+ beq pdump_dot
+ jsr oswrch
+.pdump_l4
+ iny
+ dex
+ bne pdump_l3
+ jsr osnewl
+ jsr check_esc
+ bcs pdump_end
+ cpy #0
+ bne pdump_l1
+ inc load_addr+1
+ bne pdump_l1
+
+.pdump_end
+ jsr set_bank_0
+ jmp call_claimed
+
+.pdump_dot
+ lda #'.'
+ jsr oswrch
+ jmp pdump_l4
+
+; MOS output and interrupt handlers may use JIM. Reassert the complete direct
+; address, or the AP5-visible page, immediately before every data access.
+.pdump_read_y
+ php
+ sei
+ lda driver_machine
+ cmp #1
+ beq pdump_read_page
+ lda #0
+ sta &FCFD
+ jsr bus_delay
+ lda pdump_bank
+ sta &FCFE
+ jsr bus_delay
+.pdump_read_page
+ lda load_addr+1
+ sta pagereg
+ jsr bus_delay
+ lda pageram,y
+ plp
+ ora #0
+ rts

--- a/beeb/1mhz-wifi/src/ping.asm
+++ b/beeb/1mhz-wifi/src/ping.asm
@@ -1,0 +1,78 @@
+\ ElkWiFi-compatible PING through the Pi1MHz service.
+
+\ Never use errorspace (&0100) as persistent state: it is the CPU stack page.
+\ PING does not run concurrently with another driver command, so it can reuse
+\ the service driver's volatile heap range.
+ping_wait_count = heap+&B0
+ping_request_count = heap+&B1
+
+.ping_cmd
+ jsr skipspace1
+ jsr read_cli_param
+ cpx #&00
+ bne ping_start
+ jsr printtext
+ equs "Usage: *PING <hostname or IP>",&0D,&EA
+ jmp call_claimed
+
+.ping_start
+ ldx #5
+ stx ping_request_count
+\ The inherited ROM set a UART timeout at time_out here. That address is &0144,
+\ inside the processor stack, and nothing has read it since the UART went, so
+\ the store is removed rather than relocated.
+.ping_loop
+ ldx #>strbuf
+ ldy #<strbuf
+ lda #28
+ jsr wifidriver
+ lda drv_svc_cancelled
+ bne ping_cancelled
+
+ jsr reset_buffer
+ jsr read_buffer
+ cmp #'+'
+ bne ping_error
+ jsr read_buffer
+ cmp #'t'
+ beq ping_time_out
+ jsr printtext
+ equs "Received response in ",&EA
+ jsr reset_buffer
+ jsr read_buffer              \ skip the leading '+'
+.ping_print_ms
+ jsr read_buffer              \ reselect FCFF after every MOS call
+ cmp #&0D
+ beq ping_ms
+ sta save_y
+ jsr oswrch
+ lda save_y
+ bpl ping_print_ms
+.ping_ms
+ jsr printtext
+ equs " ms",&0D,&EA
+.ping_wait
+ ldx #50
+ stx ping_wait_count
+.ping_wait_loop
+ jsr check_esc
+ bcs ping_cancelled
+ lda #19
+ jsr osbyte
+ dec ping_wait_count
+ bne ping_wait_loop
+
+ dec ping_request_count
+ bne ping_loop
+.ping_cancelled
+ jmp call_claimed
+
+.ping_error
+ jsr printtext
+ equs "Host error (dns or network)",&0D,&EA
+ jmp ping_wait
+
+.ping_time_out
+ jsr printtext
+ equs "No response received from host",&0D,&EA
+ jmp ping_wait

--- a/beeb/1mhz-wifi/src/ramdisk.asm
+++ b/beeb/1mhz-wifi/src/ramdisk.asm
@@ -1,0 +1,644 @@
+\ ramdisk.asm
+\ 1MHz-WiFi ROM: a RAM disk in the Pi1MHz JIM window.
+\
+\ Written for the 1MHz-WiFi project. This is what replaces the cassette filing
+\ system for getting a program into the machine: fetch it over WiFi, keep it in
+\ the Pi's memory, and load or run it from there. No part of it derives from
+\ anyone else's work.
+\
+\ The store is the low 64 KiB JIM window, which is the one window every target
+\ machine can reach. An unmodified Electron AP5 forwards only bank 0, so a
+\ format that needed the upper banks would work on the BBC family and not on
+\ the Electron; select_public_page_a hides that difference and everything here
+\ stays inside bank 0 so all four machines behave identically.
+\
+\ Layout. Page 0 is the service reply buffer that OSWORD &65 clients read, so
+\ it is left alone. Page 1 is the catalogue. Files follow from page 2, each
+\ starting on a page boundary, which is what makes a file's position a single
+\ byte and the whole of the arithmetic below a page counter.
+\
+\   catalogue page   +0,1   signature
+\                    +2     number of entries
+\                    +3     next free page
+\                    +16    fifteen entries of sixteen bytes
+\
+\   entry            +0..6  name, padded with spaces
+\                    +7,8   load address
+\                    +9,10  execution address
+\                    +11,12 length
+\                    +13    first page
+\                    +14,15 spare
+\
+\ Sixteen bytes an entry means the offset of entry N is four shifts and an add,
+\ which is why the entry is that size rather than the eleven bytes it needs.
+
+rd_cat_page      = 1            \ catalogue page within the window
+rd_first_page    = 2            \ files start here
+rd_max_entries   = 15           \ what fits in one page after the header
+rd_entry_size    = 16
+rd_name_size     = 7
+rd_sig_0         = 'R'
+rd_sig_1         = 'D'
+
+\ Command workspace. heap+&C0 to &DF is not claimed by any other command, and
+\ no two of these commands run at once.
+rd_page          = heap+&C0     \ page being read or written
+rd_offset        = heap+&C1     \ offset within that page
+\ The host memory pointer must be in zero page for (rd_addr),Y. load_addr is
+\ the ROM's pointer pair for exactly this and no other command is running.
+rd_addr          = load_addr
+rd_entry         = heap+&C6     \ catalogue offset of the entry in hand
+rd_count         = heap+&C7     \ entries in the catalogue
+rd_next          = heap+&C8     \ next free page
+rd_name          = heap+&C9     \ the name being matched, seven bytes
+
+\ Load, execution and length are read and written as one six byte run, both
+\ here and in the catalogue entry, so they must stay adjacent and in this
+\ order. Putting the length elsewhere silently records a zero.
+rd_load          = heap+&D0     \ two bytes
+rd_exec          = heap+&D2     \ two bytes
+rd_len           = heap+&D4     \ two bytes, counted down by the copy
+
+rd_start         = heap+&D6     \ first page of the file in hand
+rd_index         = heap+&D7     \ entry number while walking the catalogue
+rd_temp          = heap+&D8
+rd_hold          = heap+&D9     \ byte held across a Y restore
+
+\ ===========================================================================
+\ Window access
+\ ===========================================================================
+\ Read the byte at rd_page,rd_offset. Interrupts are held off across the pair
+\ because the page register and the aperture are shared with other JIM users.
+\ Returns the byte in A; Y is not preserved.
+
+\ Y is preserved because Y is the MOS command line pointer, and every command
+\ here reads the catalogue before it has finished parsing its arguments.
+
+.rd_read            php
+                    sei
+                    tya
+                    pha
+                    lda rd_page
+                    jsr select_public_page_a
+                    ldy rd_offset
+                    lda pageram,y
+                    sta rd_hold
+                    pla
+                    tay
+                    lda rd_hold
+                    plp
+                    rts
+
+\ Write A at rd_page,rd_offset.
+
+.rd_write           php
+                    sei
+                    sta rd_temp
+                    tya
+                    pha
+                    lda rd_page
+                    jsr select_public_page_a
+                    ldy rd_offset
+                    lda rd_temp
+                    sta pageram,y
+                    jsr bus_delay
+                    pla
+                    tay
+                    plp
+                    rts
+
+\ Step the cursor on one byte, carrying into the page.
+
+.rd_step            inc rd_offset
+                    bne rd_step_done
+                    inc rd_page
+.rd_step_done       rts
+
+\ Point the cursor at the catalogue byte in A.
+
+.rd_cat_at          sta rd_offset
+                    lda #rd_cat_page
+                    sta rd_page
+                    rts
+
+\ ===========================================================================
+\ Catalogue
+\ ===========================================================================
+\ Read the header. Carry clear and rd_count/rd_next loaded if the signature is
+\ present; carry set if the window holds no RAM disk.
+
+.rd_open            lda #0
+                    jsr rd_cat_at
+                    jsr rd_read
+                    cmp #rd_sig_0
+                    bne rd_open_bad
+                    lda #1
+                    jsr rd_cat_at
+                    jsr rd_read
+                    cmp #rd_sig_1
+                    bne rd_open_bad
+                    lda #2
+                    jsr rd_cat_at
+                    jsr rd_read
+                    sta rd_count
+                    lda #3
+                    jsr rd_cat_at
+                    jsr rd_read
+                    sta rd_next
+                    clc
+                    rts
+.rd_open_bad        sec
+                    rts
+
+\ Write the header back from rd_count and rd_next.
+
+.rd_commit          lda #2
+                    jsr rd_cat_at
+                    lda rd_count
+                    jsr rd_write
+                    lda #3
+                    jsr rd_cat_at
+                    lda rd_next
+                    jmp rd_write
+
+\ Set rd_entry to the catalogue offset of entry rd_index.
+\ offset = 16 + index * 16, which cannot exceed 255 for fifteen entries.
+
+.rd_entry_offset    lda rd_index
+                    asl a
+                    asl a
+                    asl a
+                    asl a
+                    clc
+                    adc #rd_entry_size
+                    sta rd_entry
+                    rts
+
+\ Load the entry in hand into rd_load, rd_exec, rd_len and rd_start.
+
+.rd_entry_fields    jsr rd_entry_offset
+                    ldx #0
+.rd_field_loop      lda rd_entry
+                    clc
+                    adc #rd_name_size
+                    sta rd_temp
+                    txa
+                    clc
+                    adc rd_temp
+                    jsr rd_cat_at
+                    jsr rd_read
+                    sta rd_load,x           \ load, exec and length are stored
+                    inx                     \ in that order and read as a run
+                    cpx #6
+                    bne rd_field_loop
+                    lda rd_entry
+                    clc
+                    adc #13
+                    jsr rd_cat_at
+                    jsr rd_read
+                    sta rd_start
+                    rts
+
+\ ===========================================================================
+\ Name handling
+\ ===========================================================================
+\ Copy the command line parameter in strbuf into rd_name, padded with spaces
+\ and truncated to the field width, so a comparison is a fixed seven bytes.
+
+.rd_set_name        ldx #0
+.rd_name_copy       lda strbuf,x
+                    cmp #&0D
+                    beq rd_name_pad
+                    jsr rd_upper
+                    sta rd_name,x
+                    inx
+                    cpx #rd_name_size
+                    bne rd_name_copy
+                    rts
+.rd_name_pad        lda #' '
+.rd_name_pad_loop   sta rd_name,x
+                    inx
+                    cpx #rd_name_size
+                    bne rd_name_pad_loop
+                    rts
+
+\ Fold a to z to upper case so names match however they were typed.
+
+.rd_upper           cmp #'a'
+                    bcc rd_upper_done
+                    cmp #'z'+1
+                    bcs rd_upper_done
+                    and #&DF
+.rd_upper_done      rts
+
+\ Find rd_name in the catalogue. Carry clear with rd_index set and the entry
+\ fields loaded if it is there, carry set if it is not.
+
+.rd_find            lda #0
+                    sta rd_index
+.rd_find_entry      lda rd_index
+                    cmp rd_count
+                    bcs rd_find_missing
+                    jsr rd_entry_offset
+                    ldx #0
+.rd_find_char       txa
+                    clc
+                    adc rd_entry
+                    jsr rd_cat_at
+                    jsr rd_read
+                    cmp rd_name,x
+                    bne rd_find_next
+                    inx
+                    cpx #rd_name_size
+                    bne rd_find_char
+                    jsr rd_entry_fields
+                    clc
+                    rts
+.rd_find_next       inc rd_index
+                    bne rd_find_entry       \ always: rd_count is at most 15
+.rd_find_missing    sec
+                    rts
+
+\ ===========================================================================
+\ *RDINIT
+\ ===========================================================================
+\ Write an empty catalogue. This discards whatever the window held, which is
+\ the only way to reclaim space, since entries are never removed individually.
+
+.rd_init_cmd        jsr detect_jim_machine
+                    lda #0
+                    jsr rd_cat_at
+                    lda #rd_sig_0
+                    jsr rd_write
+                    lda #1
+                    jsr rd_cat_at
+                    lda #rd_sig_1
+                    jsr rd_write
+                    lda #0
+                    sta rd_count
+                    lda #rd_first_page
+                    sta rd_next
+                    jsr rd_commit
+                    jsr printtext
+                    equs "RAM disk cleared",&0D,&EA
+                    jmp call_claimed
+
+\ ===========================================================================
+\ *RDCAT
+\ ===========================================================================
+
+.rd_cat_cmd         jsr detect_jim_machine
+                    jsr rd_open
+                    bcc rd_cat_have_disk
+                    jmp rd_no_disk
+.rd_cat_have_disk
+                    jsr printtext
+                    equs "RAM disk",&0D,&EA
+                    lda #0
+                    sta rd_index
+.rd_cat_next        lda rd_index
+                    cmp rd_count
+                    bcs rd_cat_free
+                    jsr rd_entry_fields
+                    ldx #0
+.rd_cat_name        txa
+                    clc
+                    adc rd_entry
+                    jsr rd_cat_at
+                    jsr rd_read
+                    jsr osasci
+                    inx
+                    cpx #rd_name_size
+                    bne rd_cat_name
+                    lda #' '
+                    jsr osasci
+                    lda rd_load+1           \ load address, high byte first
+                    jsr printhex
+                    lda rd_load
+                    jsr printhex
+                    lda #' '
+                    jsr osasci
+                    lda rd_exec+1
+                    jsr printhex
+                    lda rd_exec
+                    jsr printhex
+                    lda #' '
+                    jsr osasci
+                    lda rd_len+1
+                    jsr printhex
+                    lda rd_len
+                    jsr printhex
+                    jsr osnewl
+                    inc rd_index
+                    bne rd_cat_next
+.rd_cat_free        jsr printtext
+                    equs "Pages used ",&EA
+                    lda rd_next
+                    jsr printhex
+                    jsr printtext
+                    equs " of FF",&0D,&EA
+                    jmp call_claimed
+
+.rd_no_disk         jsr printtext
+                    equs "No RAM disk; use *RDINIT",&0D,&EA
+                    jmp call_claimed
+
+.rd_not_found       jsr printtext
+                    equs "Not found",&0D,&EA
+                    jmp call_claimed
+
+\ ===========================================================================
+\ *RDLOAD <name> [address]
+\ ===========================================================================
+\ Copy a file out of the window into host memory, at its recorded load address
+\ or at one given on the command line.
+
+.rd_load_cmd        jsr detect_jim_machine
+                    jsr rd_open
+                    bcc rd_load_have_disk
+                    jmp rd_no_disk
+.rd_load_have_disk
+                    jsr skipspace1
+                    jsr read_cli_param
+                    cpx #0
+                    beq rd_usage_load
+                    jsr rd_set_name
+                    jsr rd_find
+                    bcc rd_load_found
+                    jmp rd_not_found
+.rd_load_found
+
+                    jsr skipspace1          \ an address overrides the entry's
+                    jsr read_cli_param
+                    cpx #0
+                    beq rd_load_at_entry
+                    jsr rd_hex_to_addr
+                    bcc rd_load_go
+.rd_load_at_entry   lda rd_load
+                    sta rd_addr
+                    lda rd_load+1
+                    sta rd_addr+1
+.rd_load_go         jsr rd_copy_out
+                    jmp call_claimed
+
+.rd_usage_load      jsr printtext
+                    equs "Usage: RDLOAD <name> [addr]",&0D,&EA
+                    jmp call_claimed
+
+\ Convert the parameter in strbuf to rd_addr. Carry clear if it was a number.
+
+.rd_hex_to_addr     ldx #<zp
+                    jsr string2hex
+                    cmp #0
+                    beq rd_hex_none
+                    lda zp
+                    sta rd_addr
+                    lda zp+1
+                    sta rd_addr+1
+                    clc
+                    rts
+.rd_hex_none        sec
+                    rts
+
+\ Copy rd_len bytes from page rd_start to rd_addr.
+\
+\ The page is selected once per page rather than once per byte. Selecting
+\ costs two JIM selector writes and three bus settling delays on a BBC family
+\ host, so doing it per byte would spend far longer settling the bus than
+\ moving data; a sixteen kilobyte file would take seconds. Y indexes the
+\ window and the destination together, which is why rd_addr is kept pointing
+\ at the byte matching offset zero of the current page rather than at the next
+\ byte to write.
+
+.rd_copy_out        lda rd_start
+                    sta rd_page
+                    ldy #0
+.rd_out_page        lda rd_len
+                    ora rd_len+1
+                    beq rd_copy_done
+                    php
+                    sei                     \ the selector is shared, so hold
+                    lda rd_page             \ it across the page
+                    jsr select_public_page_a
+.rd_out_byte        lda pageram,y
+                    sta (rd_addr),y
+                    lda rd_len
+                    bne rd_out_low
+                    dec rd_len+1
+.rd_out_low         dec rd_len
+                    lda rd_len
+                    ora rd_len+1
+                    beq rd_out_page_done
+                    iny
+                    bne rd_out_byte
+.rd_out_page_done   plp
+                    tya
+                    bne rd_copy_done        \ stopped mid page: nothing to step
+                    inc rd_page
+                    inc rd_addr+1
+                    jmp rd_out_page
+.rd_copy_done       rts
+
+\ ===========================================================================
+\ *RDSAVE <name> <start> <end> [exec]
+\ ===========================================================================
+
+.rd_save_cmd        jsr detect_jim_machine
+                    jsr rd_open
+                    bcc rd_save_have_disk
+                    jmp rd_no_disk
+.rd_save_have_disk
+                    lda rd_count
+                    cmp #rd_max_entries
+                    bcc rd_save_room
+                    jmp rd_full
+.rd_save_room
+                    jsr skipspace1
+                    jsr read_cli_param
+                    cpx #0
+                    beq rd_save_usage_near
+                    jsr rd_set_name
+
+                    jsr skipspace1          \ start address
+                    jsr read_cli_param
+                    cpx #0
+                    beq rd_save_usage_near
+                    jsr rd_hex_to_addr
+                    bcs rd_save_usage_near
+                    lda rd_addr
+                    sta rd_load
+                    lda rd_addr+1
+                    sta rd_load+1
+
+                    jsr skipspace1          \ end address, exclusive
+                    jsr read_cli_param
+                    cpx #0
+                    beq rd_save_usage_near
+                    ldx #<zp
+                    jsr string2hex
+                    sec                     \ length = end - start
+                    lda zp
+                    sbc rd_load
+                    sta rd_len
+                    lda zp+1
+                    sbc rd_load+1
+                    sta rd_len+1
+
+                    lda rd_load             \ execution address defaults to
+                    sta rd_exec             \ the load address
+                    lda rd_load+1
+                    sta rd_exec+1
+                    jsr skipspace1
+                    jsr read_cli_param
+                    cpx #0
+                    beq rd_save_store
+                    ldx #<zp
+                    jsr string2hex
+                    lda zp
+                    sta rd_exec
+                    lda zp+1
+                    sta rd_exec+1
+                    jmp rd_save_store       \ or the exec case falls into usage
+
+.rd_save_usage_near jmp rd_usage_save
+
+\ Record the entry before copying, because the copy counts rd_len down to zero
+\ and the entry has to carry the real length. Writing it early is safe: an
+\ entry is not visible until rd_count is raised, which only happens once the
+\ copy has succeeded.
+.rd_save_store      lda rd_next
+                    sta rd_start
+                    jsr rd_entry_write
+                    jsr rd_copy_in
+                    bcc rd_save_stored
+                    jmp rd_full
+.rd_save_stored     inc rd_count
+                    jsr rd_commit
+                    jmp call_claimed
+
+.rd_usage_save      jsr printtext
+                    equs "Usage: RDSAVE <name> <start> <end> [exec]",&0D,&EA
+                    jmp call_claimed
+
+.rd_full            jsr printtext
+                    equs "RAM disk full",&0D,&EA
+                    jmp call_claimed
+
+\ Copy rd_len bytes from rd_load into the window at rd_start, advancing
+\ rd_next past them. Carry set if the window would overflow. The page is
+\ selected once per page, as above.
+
+.rd_copy_in         lda rd_load
+                    sta rd_addr
+                    lda rd_load+1
+                    sta rd_addr+1
+                    lda rd_start
+                    sta rd_page
+                    ldy #0
+.rd_in_page         lda rd_len
+                    ora rd_len+1
+                    beq rd_in_done
+                    lda rd_page
+                    beq rd_in_overflow      \ wrapped past the top of the window
+                    php
+                    sei
+                    lda rd_page
+                    jsr select_public_page_a
+.rd_in_byte         lda (rd_addr),y
+                    sta pageram,y
+                    lda rd_len
+                    bne rd_in_low
+                    dec rd_len+1
+.rd_in_low          dec rd_len
+                    lda rd_len
+                    ora rd_len+1
+                    beq rd_in_page_done
+                    iny
+                    bne rd_in_byte
+.rd_in_page_done    jsr bus_delay           \ settle the last write of the page
+                    plp
+                    tya
+                    beq rd_in_whole_page
+                    inc rd_page             \ part of a page used; round up
+                    jmp rd_in_done
+.rd_in_whole_page   inc rd_page
+                    inc rd_addr+1
+                    jmp rd_in_page
+.rd_in_done         lda rd_page
+                    sta rd_next
+                    clc
+                    rts
+.rd_in_overflow     sec
+                    rts
+
+\ Write the entry described by rd_name, rd_load, rd_exec, rd_len and rd_start
+\ at index rd_count.
+
+.rd_entry_write     lda rd_count
+                    sta rd_index
+                    jsr rd_entry_offset
+                    ldx #0
+.rd_write_name      txa
+                    clc
+                    adc rd_entry
+                    jsr rd_cat_at
+                    lda rd_name,x
+                    jsr rd_write
+                    inx
+                    cpx #rd_name_size
+                    bne rd_write_name
+                    ldx #0
+.rd_write_fields    lda rd_entry
+                    clc
+                    adc #rd_name_size
+                    sta rd_temp
+                    txa
+                    clc
+                    adc rd_temp
+                    jsr rd_cat_at
+                    lda rd_load,x
+                    jsr rd_write
+                    inx
+                    cpx #6
+                    bne rd_write_fields
+                    lda rd_entry
+                    clc
+                    adc #13
+                    jsr rd_cat_at
+                    lda rd_start
+                    jmp rd_write
+
+\ ===========================================================================
+\ *RDRUN <name>
+\ ===========================================================================
+\ Load a file and enter it at its execution address. The jump is indirect
+\ through the zero page pair, so a program may be entered anywhere.
+
+.rd_run_cmd         jsr detect_jim_machine
+                    jsr rd_open
+                    bcc rd_run_have_disk
+                    jmp rd_no_disk
+.rd_run_have_disk
+                    jsr skipspace1
+                    jsr read_cli_param
+                    cpx #0
+                    beq rd_usage_run
+                    jsr rd_set_name
+                    jsr rd_find
+                    bcc rd_run_found
+                    jmp rd_not_found
+.rd_run_found
+                    lda rd_load
+                    sta rd_addr
+                    lda rd_load+1
+                    sta rd_addr+1
+                    jsr rd_copy_out
+                    lda rd_exec
+                    sta zp
+                    lda rd_exec+1
+                    sta zp+1
+                    jmp (zp)
+
+.rd_usage_run       jsr printtext
+                    equs "Usage: RDRUN <name>",&0D,&EA
+                    jmp call_claimed

--- a/beeb/1mhz-wifi/src/serial.asm
+++ b/beeb/1mhz-wifi/src/serial.asm
@@ -1,0 +1,85 @@
+\ Pi1MHz JIM helpers retained under the stock ElkWiFi labels. An unmodified
+\ Electron AP5 forwards only &FCFF and JIM, so it must not touch &FCFD/&FCFE.
+\ Direct BBC-family Pi1MHz systems expose those selectors and must explicitly
+\ return them to bank 00:00 after another JIM client has changed them.
+
+.detect_jim_machine
+ pha
+ txa
+ pha
+ tya
+ pha
+ lda #&81
+ ldx #0
+ ldy #&FF
+ jsr osbyte
+ stx driver_machine
+ pla
+ tay
+ pla
+ tax
+ pla
+ rts
+
+.set_bank_0
+ lda #0
+ jsr select_public_page_a
+ lda #0
+ rts
+
+\ Select JIM address 00:00:A while preserving X. Electron/AP5 does not forward
+\ FCFD/FCFE; direct BBC-family hosts must reassert them in every masked JIM
+\ transaction because another expansion or interrupt handler may change them.
+.select_public_page_a
+ pha
+ txa
+ pha
+ lda #0
+ ldx driver_machine
+ cpx #1
+ beq set_bank_0_page
+ sta &FCFD
+ jsr bus_delay
+ sta &FCFE
+ jsr bus_delay
+.set_bank_0_page
+ pla
+ tax
+ pla
+ sta pagereg
+ jsr bus_delay
+ rts
+
+set_bank_1 = set_bank_0
+
+\ Settle the 1MHz bus after touching a Pi1MHz register. The Pi needs time to
+\ see a write and publish a reply, and the host must not read back sooner.
+\ A and the flags are preserved so this can be dropped between any pair of
+\ accesses. Written for this project; it lived in the filing system source
+\ only because that is where the first caller happened to be.
+
+.bus_delay          php
+                    pha
+                    lda #64
+.bus_delay_loop     sec
+                    sbc #1
+                    bne bus_delay_loop
+                    pla
+                    plp
+                    rts
+
+
+\ Point the Pi1MHz service cursor at persisted state byte X, which lives in
+\ the reserved services buffer at &FFEF00. Leaves the cursor set so the
+\ caller can read or write &FCA9 directly.
+
+.pi_state_address_x txa
+                    sta &FCA6
+                    jsr bus_delay
+                    lda #&EF
+                    sta &FCA7
+                    jsr bus_delay
+                    lda #&FF
+                    sta &FCA8
+                    jsr bus_delay
+                    rts

--- a/beeb/1mhz-wifi/src/service_driver.asm
+++ b/beeb/1mhz-wifi/src/service_driver.asm
@@ -1,0 +1,1465 @@
+\ ElkWiFi driver calls implemented through the Pi1MHz services mailbox.
+\ This service ROM executes in the host I/O processor, including when invoked
+\ by a Tube parasite, so use the 1MHz-bus FRED window directly.
+
+drv_svc_addr_lo = &A6
+drv_svc_addr_mid = &A7
+drv_svc_addr_hi = &A8
+drv_svc_data = &A9
+drv_svc_command = &AA
+drv_svc_guard_image = 86  \publish the host filing-vector guard
+drv_uef_sbuft = &F5
+drv_uef_sbufl = &F8
+drv_uef_sbufh = &F9
+drv_uef_pr_y = &C7
+drv_uef_pr_r = &C8
+
+drv_svc_status = 80
+drv_svc_scan = 81
+drv_svc_join = 82
+drv_svc_ifcfg = 83
+drv_svc_lapopt = 87
+drv_svc_ping = 88
+drv_svc_datetime = 89
+drv_svc_cancel = 90
+drv_svc_radio = 91
+drv_svc_online = 92
+drv_svc_vector_mirror = 86
+drv_svc_uef_normalize = 93
+drv_svc_uef_op_probe = 0
+drv_svc_uef_op_begin = 1
+drv_svc_uef_op_append = 2
+drv_svc_uef_op_finalize = 3
+drv_svc_uef_op_rewind = 4
+drv_svc_uef_op_refill = 5
+drv_svc_uef_op_close = 6
+drv_svc_uef_op_republish = 7
+uef_first_page = 1
+drv_net_copy_public = 58
+drv_net_unsupported = &27
+
+\ Sixteen DEX/BNE iterations take 79 processor cycles. Even at the host's
+\ maximum 2 MHz rate this is at least 39.5 us, comfortably beyond the
+\ measured 6.8 us Pi Zero page-publication worst case. No FRED/JIM access is
+\ permitted in this delay because every such access posts a newer FIQ event.
+drv_svc_settle_iterations = 16
+
+\ `errorspace` is &0100 on the Electron, which is the CPU stack page. The
+\ general `heap` is &0900 and belongs to the current language or application.
+\ Neither is safe for an OSWORD driver entered by an arbitrary application.
+\ Reuse the original ElkWiFi network-printer workspace instead. PRINTER is not
+\ part of 1MHzWifi and the original ROM reserves &0D90-&0DAF for `netprt`.
+\ This gives the compatibility driver private transient state without writing
+\ into ElkChat code or its live return stack.
+drv_svc_workspace = netprt
+drv_svc_timeout_lo = drv_svc_workspace+0
+drv_svc_timeout_hi = drv_svc_workspace+1
+drv_svc_saved_x = drv_svc_workspace+2
+drv_svc_strings = drv_svc_workspace+3
+drv_net_index = drv_svc_workspace+4
+drv_net_port_lo = drv_svc_workspace+5
+drv_net_port_hi = drv_svc_workspace+6
+drv_net_chunk = drv_svc_workspace+7
+drv_svc_cursor = drv_svc_workspace+8
+drv_net_copy_count = drv_svc_workspace+9
+drv_net_buf_x = drv_svc_workspace+10
+drv_svc_response_count = drv_svc_workspace+11
+drv_svc_timeout_outer = drv_svc_workspace+12
+drv_svc_command_copy = drv_svc_workspace+13
+drv_svc_cancelled = drv_svc_workspace+14
+
+\ Function 8 must retain all four DNS bytes while subsequent mailbox reads
+\ continue to use the shared cursor. These bytes complete the 19-byte block
+\ inside the original 32-byte `netprt` allocation.
+drv_net_ip = drv_svc_workspace+15
+drv_net_type = drv_svc_workspace+24
+drv_net_protocol_second = drv_svc_workspace+25
+drv_uef_op = drv_svc_workspace+26
+drv_uef_stream_pending = drv_svc_workspace+27
+drv_uef_upload_active = drv_svc_workspace+28
+drv_uef_format = drv_svc_workspace+29
+drv_uef_generation_lo = drv_svc_workspace+30
+drv_uef_generation_hi = drv_svc_workspace+31
+drv_uef_generation_record_lo = 26
+drv_uef_generation_record_hi = 27
+
+drv_net_open = 45
+drv_net_dns = 46
+drv_net_connect = 47
+drv_net_send = 50
+drv_net_recv = 51
+drv_net_close = 53
+drv_net_status = 54
+
+.service_driver_init
+\Functions 0 and 1 reset the original ESP module. Pi1MHz has no separate
+\cartridge processor to reset, so close volatile TCP state and return a
+\normal driver response without disturbing the saved WiFi association.
+.service_driver_reset
+ jsr service_driver_net_close_silent
+ ldx #<service_driver_ok_text
+ ldy #>service_driver_ok_text
+ jmp service_driver_rom_response
+
+.service_driver_version
+ lda #drv_svc_status
+ jmp service_driver_begin
+
+.service_driver_scan
+ lda #drv_svc_scan
+ jmp service_driver_begin
+
+.service_driver_ifcfg
+ lda #drv_svc_ifcfg
+ jmp service_driver_begin
+
+.service_driver_online
+ lda #drv_svc_online
+ jmp service_driver_begin
+
+\Normalize the UEF window in place. Return only the first response character
+\in A: copying the response into pageram would overwrite the UEF header.
+.service_driver_uef_normalize
+ lda #drv_svc_uef_normalize
+ jsr service_driver_write_command
+ \ Old Pi firmware left the capability byte undefined. Clear it before the
+ \ legacy request so fallback cannot be enabled by stale mailbox contents.
+ lda #17
+ sta drv_svc_cursor
+ ldy #0
+ jsr service_driver_write_y
+ jsr service_driver_dispatch
+ pha
+ lda #17
+ sta drv_svc_cursor
+ jsr service_driver_read_a
+ cmp #'1'
+ bne service_driver_uef_normalize_legacy
+ lda #&80
+ sta drv_uef_stream_pending
+ bne service_driver_uef_normalize_done
+.service_driver_uef_normalize_legacy
+ lda #0
+ sta drv_uef_stream_pending
+.service_driver_uef_normalize_done
+ pla
+ rts
+
+\ Rewind or refill the Pi-private UEF stream. These calls deliberately use
+\ command 93 with an exact guarded request, preserving commands 94-113 for
+\ the secure NetTools service. On return sbuf is the published window length,
+\ sbuft bit 6 says it is the final window, and pr_r/pr_y select its first byte.
+.service_driver_uef_stream_republish
+ lda #drv_svc_uef_op_republish
+ bne service_driver_uef_stream
+.service_driver_uef_stream_rewind
+ lda #drv_svc_uef_op_rewind
+ bne service_driver_uef_stream
+.service_driver_uef_stream_refill
+ lda #drv_svc_uef_op_refill
+.service_driver_uef_stream
+ sta drv_uef_op
+ cmp #drv_svc_uef_op_refill
+ beq service_driver_uef_stream_restore_generation
+ cmp #drv_svc_uef_op_append
+ bne service_driver_uef_stream_generation_ready
+.service_driver_uef_stream_restore_generation
+ jsr service_driver_uef_generation_load
+.service_driver_uef_stream_generation_ready
+ lda #drv_svc_uef_normalize
+ jsr service_driver_write_command
+ ldx #0
+.service_driver_uef_stream_request
+ lda service_driver_uef_stream_template,x
+ cpx #5
+ beq service_driver_uef_stream_operation
+ cpx #10
+ beq service_driver_uef_stream_generation_lo
+ cpx #11
+ beq service_driver_uef_stream_generation_hi
+ bne service_driver_uef_stream_byte
+.service_driver_uef_stream_operation
+ lda drv_uef_op
+ jmp service_driver_uef_stream_byte
+.service_driver_uef_stream_generation_lo
+ lda drv_uef_op
+ cmp #drv_svc_uef_op_refill
+ beq service_driver_uef_stream_generation_lo_send
+ cmp #drv_svc_uef_op_append
+ bne service_driver_uef_stream_zero
+.service_driver_uef_stream_generation_lo_send
+ lda drv_uef_generation_lo
+ jmp service_driver_uef_stream_byte
+.service_driver_uef_stream_generation_hi
+ lda drv_uef_op
+ cmp #drv_svc_uef_op_refill
+ beq service_driver_uef_stream_generation_hi_send
+ cmp #drv_svc_uef_op_append
+ bne service_driver_uef_stream_zero
+.service_driver_uef_stream_generation_hi_send
+ lda drv_uef_generation_hi
+ jmp service_driver_uef_stream_byte
+.service_driver_uef_stream_zero
+ lda #0
+.service_driver_uef_stream_byte
+ tay
+ jsr service_driver_write_y
+ inx
+ cpx #20
+ bne service_driver_uef_stream_request
+ jsr service_driver_dispatch
+ cmp #'I'
+ bne service_driver_uef_stream_invalid
+ ldx #0
+.service_driver_uef_stream_signature
+ jsr service_driver_read_a
+ cmp service_driver_uef_stream_reply,x
+ bne service_driver_uef_stream_invalid
+ inx
+ cpx #4
+ bne service_driver_uef_stream_signature
+ \ A republish only repairs bytes the host has already been handed. Window
+ \ length, final flag, generation and read cursor all still describe where the
+ \ host is, so take none of them from the reply.
+ lda drv_uef_op
+ cmp #drv_svc_uef_op_republish
+ beq service_driver_uef_stream_repaired
+ ldx #4
+.service_driver_uef_stream_skip_token
+ jsr service_driver_read_a
+ dex
+ bne service_driver_uef_stream_skip_token
+ jsr service_driver_read_a
+ sta drv_uef_generation_lo
+ jsr service_driver_read_a
+ sta drv_uef_generation_hi
+ jsr service_driver_uef_generation_save
+ jsr service_driver_read_a
+ jsr service_driver_read_a
+ jsr service_driver_read_a
+ sta drv_uef_sbufl
+ jsr service_driver_read_a
+ sta drv_uef_sbufh
+ jsr service_driver_read_a
+ beq service_driver_uef_stream_not_final
+ lda drv_uef_sbuft
+ ora #&40
+ bne service_driver_uef_stream_store_flags
+.service_driver_uef_stream_not_final
+ lda drv_uef_sbuft
+ and #&BF
+.service_driver_uef_stream_store_flags
+ ora #&80
+ sta drv_uef_sbuft
+ \ The reply buffer owns JIM page 0 in full: ElkChat and other OSWORD &65
+ \ clients read up to 241 contiguous bytes from it, so the published stream
+ \ starts at page 1 instead. Nothing then has to be repaired when a service
+ \ reply lands while a UEF is being read.
+ lda #0
+ sta drv_uef_pr_y
+ lda #uef_first_page
+ sta drv_uef_pr_r
+ jsr service_driver_read_a
+ sta drv_uef_format
+ clc
+ rts
+.service_driver_uef_stream_repaired
+ clc
+ rts
+.service_driver_uef_stream_invalid
+ sec
+ rts
+
+\ The active window generation must survive arbitrary cassette loaders. Some
+\ Electron loaders occupy &0900-&10FF, which includes the original netprt
+\ scratch allocation. Keep the authoritative copy next to the transactional
+\ WiCFS record in Pi-private JIM, outside host RAM. Every refill restores this
+\ copy before constructing its request, so overwriting netprt is harmless.
+.service_driver_uef_generation_load
+ php
+ sei
+ pha
+ txa
+ pha
+ ldx #drv_uef_generation_record_lo
+ jsr pi_state_address_x
+ lda &FCA9
+ jsr bus_delay
+ sta drv_uef_generation_lo
+ ldx #drv_uef_generation_record_hi
+ jsr pi_state_address_x
+ lda &FCA9
+ jsr bus_delay
+ sta drv_uef_generation_hi
+ pla
+ tax
+ pla
+ plp
+ rts
+
+.service_driver_uef_generation_save
+ php
+ sei
+ pha
+ txa
+ pha
+ ldx #drv_uef_generation_record_lo
+ jsr pi_state_address_x
+ lda drv_uef_generation_lo
+ sta &FCA9
+ jsr bus_delay
+ ldx #drv_uef_generation_record_hi
+ jsr pi_state_address_x
+ lda drv_uef_generation_hi
+ sta &FCA9
+ jsr bus_delay
+ pla
+ tax
+ pla
+ plp
+ rts
+
+.service_driver_uef_stream_template
+ equs "IUEF"
+ equb 1,0
+ equb 0,0,0,0               \ current session token: zero means active
+ equb 0,0,0,0               \ synchronous next-window request
+ equb 0,0                    \ no upload payload
+ equb 0,0,0,0               \ no upload CRC
+.service_driver_uef_stream_reply
+ equs "UEF"
+ equb 1
+
+.service_driver_uef_stream_probe
+ lda #drv_svc_uef_op_probe
+ jmp service_driver_uef_stream
+.service_driver_uef_stream_begin
+ lda #drv_svc_uef_op_begin
+ jmp service_driver_uef_stream
+.service_driver_uef_stream_append
+ lda #drv_svc_uef_op_append
+ jmp service_driver_uef_stream
+.service_driver_uef_stream_finalize
+ lda #drv_svc_uef_op_finalize
+ jmp service_driver_uef_stream
+.service_driver_uef_stream_close
+ lda #drv_svc_uef_op_close
+ jmp service_driver_uef_stream
+
+.service_driver_lapopt
+ lda #drv_svc_lapopt
+ jsr service_driver_write_command
+ ldy #0
+ lda (paramblok),y
+ cmp #'7'
+ bne service_driver_lapopt_127
+ iny
+ lda (paramblok),y
+ cmp #&0D
+ bne service_driver_lapopt_bad
+ ldy #7
+ bne service_driver_lapopt_send
+.service_driver_lapopt_127
+ ldy #0
+ lda (paramblok),y
+ cmp #'1'
+ bne service_driver_lapopt_bad
+ iny
+ lda (paramblok),y
+ cmp #'2'
+ bne service_driver_lapopt_bad
+ iny
+ lda (paramblok),y
+ cmp #'7'
+ bne service_driver_lapopt_bad
+ iny
+ lda (paramblok),y
+ cmp #&0D
+ bne service_driver_lapopt_bad
+ ldy #127
+.service_driver_lapopt_send
+ jsr service_driver_write_y
+ jmp service_driver_dispatch
+.service_driver_lapopt_bad
+ jmp service_driver_error_parameter
+
+.service_driver_mode
+ ldy #0
+ lda (paramblok),y
+ beq service_driver_wifi_mode_query
+ cmp #'1'
+ bne service_driver_wifi_mode_error
+ iny
+ lda (paramblok),y
+ cmp #&0D
+ bne service_driver_wifi_mode_error
+ ldx #<service_driver_ok_text
+ ldy #>service_driver_ok_text
+ jmp service_driver_rom_response
+.service_driver_wifi_mode_query
+ ldx #<service_driver_mode_text
+ ldy #>service_driver_mode_text
+ jmp service_driver_rom_response
+.service_driver_wifi_mode_error
+ ldx #<service_driver_error_text
+ ldy #>service_driver_error_text
+ jmp service_driver_rom_response
+
+\ Functions 10 (CWLIF) and 12 (CIPSTATUS) share the original cartridge's
+\ connection-status behaviour. Pi1MHz reports the raw handle state in byte
+\ one. Render the ESP-compatible status class without exposing Pi internals.
+.service_driver_connection_status
+ jsr net_command_address
+ lda #drv_net_status
+ jsr net_write_a
+ jsr net_dispatch_wait
+ cmp #0
+ beq service_driver_status_read
+ jmp service_driver_net_error
+.service_driver_status_read
+ jsr net_command_address
+ lda #1
+ jsr net_address_low
+ jsr net_read_a
+ cmp #4                      \ NET_ST_CONNECTED
+ beq service_driver_status_connected
+ cmp #7                      \ NET_ST_ERROR
+ beq service_driver_status_error
+ ldx #<service_driver_status_ip_text
+ ldy #>service_driver_status_ip_text
+ jmp service_driver_rom_response
+.service_driver_status_connected
+ ldx #<service_driver_status_connected_text
+ ldy #>service_driver_status_connected_text
+ jmp service_driver_rom_response
+.service_driver_status_error
+ ldx #<service_driver_status_error_text
+ ldy #>service_driver_status_error_text
+ jmp service_driver_rom_response
+
+\ Function 11 is the cartridge's local response-buffer finaliser. Preserve
+\ the caller's low-byte length exactly as ElkWiFi 0.23 does. The Pi/AP5 page
+\ selector is write-only, so the ROM's authoritative page shadow supplies
+\ the high byte.
+.service_driver_set_buffer
+ ldx driver_entry_x
+ jmp set_buffer
+
+\ The original 0.23 source routes functions 15, 16 and 17 through the same
+\ CIOBAUD query. There is no UART on Pi1MHz, so return its stable observable
+\ response rather than raising a MOS error.
+.service_driver_baud_compat
+ ldx #<service_driver_baud_text
+ ldy #>service_driver_baud_text
+ jmp service_driver_rom_response
+
+\ Watchdog and SSL-buffer controls have no Pi-side equivalent. They are safe
+\ compatibility no-ops: the Pi owns its watchdog and dynamically sizes secure
+\ service buffers.
+.service_driver_ok
+ ldx #<service_driver_ok_text
+ ldy #>service_driver_ok_text
+ jmp service_driver_rom_response
+
+\ Function 27 controls transparent transfer mode. Pi1MHz supports normal
+\ framed mode only, so query/set mode zero succeeds and mode one is rejected.
+.service_driver_mode_unsupported
+ ldy #0
+ lda (paramblok),y
+ beq service_driver_mode_query
+ cmp #'0'
+ bne service_driver_mode_error
+ iny
+ lda (paramblok),y
+ cmp #&0D
+ bne service_driver_mode_error
+ ldx #<service_driver_ok_text
+ ldy #>service_driver_ok_text
+ jmp service_driver_rom_response
+.service_driver_mode_query
+ ldx #<service_driver_cipmode_text
+ ldy #>service_driver_cipmode_text
+ jmp service_driver_rom_response
+.service_driver_mode_error
+ ldx #<service_driver_error_text
+ ldy #>service_driver_error_text
+ jmp service_driver_rom_response
+
+\ Function 9 selects connection multiplexing. Pi1MHz exposes exactly one raw
+\ TCP connection, so the original single-connection request is a successful
+\ no-op. Reject multiplexed mode rather than silently promising five sockets.
+.service_driver_cpmux
+ ldy #0
+ lda (paramblok),y
+ beq service_driver_cpmux_query
+ cmp #'0'
+ bne service_driver_cpmux_bad
+ iny
+ lda (paramblok),y
+ cmp #&0D
+ bne service_driver_cpmux_bad
+ ldx #<service_driver_ok_text
+ ldy #>service_driver_ok_text
+ jmp service_driver_rom_response
+.service_driver_cpmux_query
+ ldx #<service_driver_cipmux_text
+ ldy #>service_driver_cipmux_text
+ jmp service_driver_rom_response
+.service_driver_cpmux_bad
+ jmp service_driver_error_parameter
+
+.service_driver_unsupported
+ ldx #(error_not_implemented-error_table)
+ jmp error
+
+.service_driver_mux_channel
+ ldy #&FF                  \ single-connection mode
+ clc
+ rts
+
+.service_driver_wifi_control
+ ldx driver_entry_x
+ \ `*WIFI ON` is the quickest positive Pi-link diagnostic. Do not return a
+ \ ROM-local OK: require command 91 to make a complete FCA6/FCA9 round trip.
+ beq service_driver_wifi_off
+ lda #drv_svc_radio
+ jmp service_driver_begin
+.service_driver_wifi_off
+ lda #drv_svc_join
+ jsr service_driver_write_command
+ ldy #3
+ jsr service_driver_write_y
+ jmp service_driver_dispatch
+
+.service_driver_ping
+ lda #0
+ sta drv_svc_cancelled
+ lda #drv_svc_ping
+ jsr service_driver_write_command
+ ldx #0
+.service_driver_ping_copy
+ txa
+ tay
+ lda (paramblok),y
+ cmp #&0D
+ bne service_driver_ping_char
+ lda #0
+.service_driver_ping_char
+ stx drv_svc_saved_x
+ tay
+ jsr service_driver_write_y
+ ldx drv_svc_saved_x
+ cmp #0
+ bne service_driver_ping_more
+ jmp service_driver_dispatch
+.service_driver_ping_more
+ inx
+ bne service_driver_ping_copy
+ jmp service_driver_error_parameter
+
+.service_driver_date
+ ldy #0
+ beq service_driver_datetime
+.service_driver_time
+ ldy #1
+.service_driver_datetime
+ lda #drv_svc_datetime
+ jsr service_driver_write_command
+ jsr service_driver_write_y
+ jmp service_driver_dispatch
+
+\ Raw TCP/UDP compatibility used by OSWORD &65 and the stock DATE/TIME tools.
+.service_driver_cipstart
+ \ X/Y point at CR-separated protocol, hostname and port strings. Parse the
+ \ protocol before opening a Pi handle, so a rejected type leaves no live
+ \ transport behind. SSL is never downgraded to plaintext.
+ ldy #0
+ lda (paramblok),y
+ and #&DF
+ cmp #'T'
+ beq service_driver_protocol_tcp
+ cmp #'U'
+ beq service_driver_protocol_udp
+ jmp service_driver_protocol_unsupported
+.service_driver_protocol_tcp
+ lda #0
+ sta drv_net_type
+ lda #'C'
+ bne service_driver_protocol_second
+.service_driver_protocol_udp
+ lda #1
+ sta drv_net_type
+ lda #'D'
+.service_driver_protocol_second
+ sta drv_net_protocol_second
+ iny
+ lda (paramblok),y
+ and #&DF
+ cmp drv_net_protocol_second
+ bne service_driver_protocol_unsupported
+ iny
+ lda (paramblok),y
+ and #&DF
+ cmp #'P'
+ bne service_driver_protocol_unsupported
+ iny
+ lda (paramblok),y
+ cmp #&0D
+ bne service_driver_protocol_unsupported
+ iny
+ sty drv_net_index
+ jmp service_driver_protocol_valid
+.service_driver_protocol_unsupported
+ ldx #<service_driver_error_text
+ ldy #>service_driver_error_text
+ jmp service_driver_rom_response
+.service_driver_protocol_valid
+ jsr service_driver_net_close_silent
+ jsr net_command_address
+ lda #drv_net_open
+ jsr net_write_a
+ lda drv_net_type
+ jsr net_write_a
+ jsr net_dispatch_wait
+ cmp #0
+ beq service_driver_open_ok
+ jmp service_driver_net_error
+.service_driver_open_ok
+ jsr net_command_address
+ lda #drv_net_dns
+ jsr net_write_a
+.service_driver_copy_host
+ ldy drv_net_index
+ lda (paramblok),y
+ iny
+ bne service_driver_host_index_ok
+ jmp service_driver_error_parameter
+.service_driver_host_index_ok
+ sty drv_net_index
+ cmp #&0D
+ bne service_driver_host_char
+ lda #0
+.service_driver_host_char
+ jsr net_write_a
+ cmp #0
+ bne service_driver_copy_host
+ jsr net_dispatch_wait
+ cmp #0
+ beq service_driver_dns_ok
+ jmp service_driver_net_error
+.service_driver_dns_ok
+
+ \ Save resolved address before reusing the command block.
+ jsr net_command_address
+ lda #4
+ jsr net_address_low
+ lda #0
+ sta drv_net_copy_count
+.service_driver_copy_ip
+ jsr net_read_a
+ ldx drv_net_copy_count
+ sta drv_net_ip,x
+ inc drv_net_copy_count
+ lda drv_net_copy_count
+ cmp #4
+ bne service_driver_copy_ip
+
+ \ Decimal TCP port follows the hostname.
+ lda #0
+ sta drv_net_port_lo
+ sta drv_net_port_hi
+.service_driver_port_digit
+ ldy drv_net_index
+ lda (paramblok),y
+ cmp #&0D
+ beq service_driver_connect
+ sec
+ sbc #'0'
+ cmp #10
+ bcc service_driver_port_valid
+ jmp service_driver_net_error
+.service_driver_port_valid
+ pha
+ lda drv_net_port_lo       \ port = port*10 + digit
+ sta zp
+ lda drv_net_port_hi
+ sta zp+1
+ asl drv_net_port_lo
+ rol drv_net_port_hi
+ asl drv_net_port_lo
+ rol drv_net_port_hi
+ lda drv_net_port_lo
+ clc
+ adc zp
+ sta drv_net_port_lo
+ lda drv_net_port_hi
+ adc zp+1
+ sta drv_net_port_hi
+ asl drv_net_port_lo
+ rol drv_net_port_hi
+ pla
+ clc
+ adc drv_net_port_lo
+ sta drv_net_port_lo
+ bcc service_driver_port_next
+ inc drv_net_port_hi
+.service_driver_port_next
+ inc drv_net_index
+ bne service_driver_port_digit
+ jmp service_driver_error_parameter
+
+.service_driver_connect
+ jsr net_command_address
+ lda #drv_net_connect
+ jsr net_write_a
+ lda #0
+ sta drv_net_index
+.service_driver_write_ip
+ ldx drv_net_index
+ lda drv_net_ip,x
+ jsr net_write_a
+ inc drv_net_index
+ lda drv_net_index
+ cmp #4
+ bne service_driver_write_ip
+ lda drv_net_port_lo
+ jsr net_write_a
+ lda drv_net_port_hi
+ jsr net_write_a
+ jsr net_dispatch_wait
+ cmp #0
+ beq service_driver_connect_ok
+ jmp service_driver_net_error
+.service_driver_connect_ok
+ ldx #<service_driver_connect_text
+ ldy #>service_driver_connect_text
+ jmp service_driver_rom_response
+
+.service_driver_cipsend
+ ldx driver_entry_x
+ lda &0000,x
+ sta data_pointer
+ lda &0001,x
+ sta data_pointer+1
+ lda &0002,x
+ sta data_counter
+ lda &0003,x
+ sta data_counter+1
+ lda &0004,x
+ sta data_counter+2
+ lda #&FF
+ sta drv_svc_timeout_hi
+.service_driver_send_more
+ lda data_counter
+ ora data_counter+1
+ ora data_counter+2
+ bne service_driver_send_pending
+ jmp service_driver_receive
+.service_driver_send_pending
+ lda #240
+ sta drv_net_chunk
+ lda data_counter+1
+ ora data_counter+2
+ bne service_driver_copy_send
+ lda data_counter
+ cmp #240
+ bcs service_driver_copy_send
+ sta drv_net_chunk
+.service_driver_copy_send
+ \ Build the scratch block without consuming the caller's source.  SEND may
+ \ accept only a prefix, so the authoritative pointer and count advance only
+ \ after Pi1MHz reports the exact number queued in command bytes 1..3.
+ lda data_pointer
+ pha
+ lda data_pointer+1
+ pha
+ lda data_counter
+ pha
+ lda data_counter+1
+ pha
+ lda data_counter+2
+ pha
+ jsr net_scratch_address
+ lda drv_net_chunk
+ sta drv_net_copy_count
+.service_driver_copy_send_byte
+ ldy #0
+ lda (data_pointer),y
+ jsr net_write_a
+ inc data_pointer
+ bne service_driver_send_pointer_ok
+ inc data_pointer+1
+.service_driver_send_pointer_ok
+ jsr dec_data_counter
+ dec drv_net_copy_count
+ bne service_driver_copy_send_byte
+
+ pla
+ sta data_counter+2
+ pla
+ sta data_counter+1
+ pla
+ sta data_counter
+ pla
+ sta data_pointer+1
+ pla
+ sta data_pointer
+
+ jsr net_command_address
+ lda #drv_net_send
+ jsr net_write_a
+ lda drv_net_chunk
+ jsr net_write_a
+ lda #0
+ jsr net_write_a
+ jsr net_write_a
+ lda #0                    \ source offset &00FFF100
+ jsr net_write_a
+ lda #&F1
+ jsr net_write_a
+ lda #&FF
+ jsr net_write_a
+ lda #0
+ jsr net_write_a
+ jsr net_dispatch_wait
+ cmp #0
+ beq service_driver_send_ok
+ jmp service_driver_net_error
+.service_driver_send_ok
+ jsr net_command_address
+ lda #1
+ jsr net_address_low
+ jsr net_read_a
+ sta drv_net_copy_count
+ jsr net_read_a
+ bne service_driver_send_count_bad
+ jsr net_read_a
+ bne service_driver_send_count_bad
+ lda drv_net_copy_count
+ beq service_driver_send_backpressure
+ cmp drv_net_chunk
+ beq service_driver_send_count_valid
+ bcc service_driver_send_count_valid
+.service_driver_send_count_bad
+ jmp service_driver_net_error
+.service_driver_send_count_valid
+ lda #&FF
+ sta drv_svc_timeout_hi
+.service_driver_advance_send
+ inc data_pointer
+ bne service_driver_advance_send_pointer_ok
+ inc data_pointer+1
+.service_driver_advance_send_pointer_ok
+ jsr dec_data_counter
+ dec drv_net_copy_count
+ bne service_driver_advance_send
+ jmp service_driver_send_more
+.service_driver_send_backpressure
+ lda #19
+ jsr osbyte
+ dec drv_svc_timeout_hi
+ beq service_driver_send_backpressure_timeout
+ jmp service_driver_send_more
+.service_driver_send_backpressure_timeout
+ jmp service_driver_no_response
+
+.service_driver_ipd
+.service_driver_receive
+ ldx #0
+ stx driver_page_shadow
+ stx drv_net_buf_x
+ stx net_empty_lo
+ lda #2                     \ up to 512 frames for the first response byte
+ sta net_empty_hi
+.service_driver_receive_more
+ jsr net_command_address
+ lda #drv_net_recv
+ jsr net_write_a
+ lda #240
+ jsr net_write_a
+ lda #0
+ jsr net_write_a
+ jsr net_write_a
+ lda #0
+ jsr net_write_a
+ lda #&F1
+ jsr net_write_a
+ lda #&FF
+ jsr net_write_a
+ lda #0
+ jsr net_write_a
+ jsr net_dispatch_wait
+ cmp #&20
+ bne service_driver_receive_not_done
+ jmp service_driver_receive_done
+.service_driver_receive_not_done
+ cmp #0
+ beq service_driver_receive_ok
+ jmp service_driver_net_error
+.service_driver_receive_ok
+ jsr net_command_address
+ lda #1
+ jsr net_address_low
+ jsr net_read_a
+ sta drv_net_chunk
+ beq service_driver_receive_empty
+ \ HTTP clients request Connection: close and normally receive explicit EOF.
+ \ Retain a bounded ten-second gap for fragmented generic TCP responses.
+ ldx #0
+ stx net_empty_lo
+ lda #2
+ sta net_empty_hi
+ jsr net_command_address
+ lda #drv_net_copy_public
+ jsr net_write_a
+ lda drv_net_chunk
+ jsr net_write_a
+ lda drv_net_buf_x
+ jsr net_write_a
+ lda driver_page_shadow
+ jsr net_write_a
+ jsr net_dispatch_wait
+ cmp #0
+ beq service_driver_receive_bulk_ok
+ cmp #drv_net_unsupported
+ beq service_driver_receive_legacy_copy
+ jmp service_driver_net_error
+.service_driver_receive_bulk_ok
+ clc
+ lda drv_net_buf_x
+ adc drv_net_chunk
+ sta drv_net_buf_x
+ bcs service_driver_receive_bulk_page
+ jmp service_driver_receive_more
+.service_driver_receive_bulk_page
+ inc driver_page_shadow
+ beq service_driver_receive_overflow
+ jmp service_driver_receive_more
+.service_driver_receive_legacy_copy
+ \ Kernels predating command 58 still expose the received bytes through the
+ \ original private scratch window. Preserve mixed ROM/kernel deployment by
+ \ falling back to ElkWiFi's byte-at-a-time copy only for UNSUPPORTED.
+ jsr net_scratch_address
+.service_driver_receive_legacy_byte
+ jsr net_read_a
+ ldx drv_net_buf_x
+ jsr service_driver_write_paged
+ inx
+ stx drv_net_buf_x
+ bne service_driver_receive_legacy_next
+ inc driver_page_shadow
+ beq service_driver_receive_overflow
+.service_driver_receive_legacy_next
+ dec drv_net_chunk
+ bne service_driver_receive_legacy_byte
+ jmp service_driver_receive_more
+.service_driver_receive_overflow
+ jmp service_driver_net_error
+.service_driver_receive_empty
+ jsr check_esc
+ bcs service_driver_receive_done
+ lda #19
+ jsr osbyte
+ dec net_empty_lo
+ beq service_driver_receive_empty_high
+ jmp service_driver_receive_more
+.service_driver_receive_empty_high
+ dec net_empty_hi
+ beq service_driver_receive_done
+ jmp service_driver_receive_more
+.service_driver_receive_done
+ ldx drv_net_buf_x
+ lda #0
+ jsr service_driver_write_paged
+ jmp restore_env
+
+.service_driver_cipclose
+ jsr service_driver_net_close_silent
+ ldx #<service_driver_close_text
+ ldy #>service_driver_close_text
+ jmp service_driver_rom_response
+
+.service_driver_net_close_silent
+ jsr net_command_address
+ lda #drv_net_close
+ jsr net_write_a
+ jsr net_dispatch_wait
+ rts
+
+.service_driver_net_error
+ pha
+ jsr service_driver_net_close_silent
+ pla
+ ldx #0
+ stx driver_page_shadow
+ lda #'E'
+ jsr service_driver_write_paged
+ inx
+ lda #'R'
+ jsr service_driver_write_paged
+ inx
+ jsr service_driver_write_paged
+ inx
+ lda #&0D
+ jsr service_driver_write_paged
+ inx
+ lda #0
+ jsr service_driver_write_paged
+ jmp restore_env
+
+\ X/Y point at a NUL-terminated ROM string.
+.service_driver_rom_response
+ stx zp
+ sty zp+1
+ ldx #0
+ stx driver_page_shadow
+ ldy #0
+.service_driver_rom_response_copy
+ lda (zp),y
+ jsr service_driver_write_paged
+ inx
+ iny
+ cmp #0
+ bne service_driver_rom_response_copy
+ dex
+ jmp restore_env
+
+.service_driver_connect_text
+ equs "CONNECT",&0D,&0A,&0D,&0A,"OK",&0D,&0A,&0D,&0A,0
+.service_driver_close_text
+ equs "CLOSED",&0D,&0A,&0D,&0A,"OK",&0D,&0A,&0D,&0A,0
+.service_driver_mode_text
+ equs "+CWMODE:1",&0D,&0A,&0D,&0A,"OK",&0D,&0A,0
+.service_driver_ok_text
+ equs "OK",&0D,&0A,0
+.service_driver_error_text
+ equs "ERROR",&0D,&0A,0
+.service_driver_status_ip_text
+ equs "STATUS:2",&0D,&0A,&0D,&0A,"OK",&0D,&0A,0
+.service_driver_status_connected_text
+ equs "STATUS:3",&0D,&0A,&0D,&0A,"OK",&0D,&0A,0
+.service_driver_status_error_text
+ equs "STATUS:4",&0D,&0A,&0D,&0A,"OK",&0D,&0A,0
+.service_driver_baud_text
+ equs "+CIOBAUD:115200",&0D,&0A,&0D,&0A,"OK",&0D,&0A,0
+.service_driver_cipmode_text
+ equs "+CIPMODE:0",&0D,&0A,&0D,&0A,"OK",&0D,&0A,0
+.service_driver_cipmux_text
+ equs "+CIPMUX:0",&0D,&0A,&0D,&0A,"OK",&0D,&0A,0
+
+.service_driver_join
+ lda #drv_svc_join
+ jsr service_driver_write_command
+ ldy #0
+ lda (paramblok),y
+ beq service_driver_join_query
+ ldy #1
+ jsr service_driver_write_y
+ lda #2
+ sta drv_svc_strings
+ ldx #0
+.service_driver_join_copy
+ txa
+ tay
+ lda (paramblok),y
+ cmp #&0D
+ bne service_driver_join_char
+ lda #0
+ dec drv_svc_strings
+.service_driver_join_char
+ stx drv_svc_saved_x
+ tay
+ jsr service_driver_write_y
+ ldx drv_svc_saved_x
+ lda drv_svc_strings
+ bne service_driver_join_more
+ jmp service_driver_dispatch
+.service_driver_join_more
+ inx
+ bne service_driver_join_copy
+ jmp service_driver_error
+.service_driver_join_query
+ ldy #0
+ jsr service_driver_write_y
+ jmp service_driver_dispatch
+
+.service_driver_leave
+ lda #drv_svc_join
+ jsr service_driver_write_command
+ ldy #2
+ jsr service_driver_write_y
+ jmp service_driver_dispatch
+
+.service_driver_begin
+ jsr service_driver_write_command
+ jmp service_driver_dispatch
+
+\ A contains the service command. Set command-page address and write byte 0.
+.service_driver_write_command
+ php
+ sei
+ pha
+ lda #0
+ sta &FC00+drv_svc_addr_lo
+ jsr service_driver_bus_settle
+ lda #&FF
+ sta &FC00+drv_svc_addr_mid
+ jsr service_driver_bus_settle
+ sta &FC00+drv_svc_addr_hi
+ jsr service_driver_bus_settle
+ \ The services emulator makes all three address bytes readable.  Check them
+ \ before touching the command block so an absent/unforwarded FCA6-FCA9 port
+ \ is reported as a missing device, rather than timing out ambiguously.
+ \ A settle is a CPU delay, not bus traffic, so the first read-back can still
+ \ carry the pre-write value on a bus that publishes writes asynchronously.
+ \ Poll the read-back the way the cursor wait does: only a port that never
+ \ agrees is an absent device.
+ txa
+ pha
+ ldx #0
+.service_driver_addr_verify
+ lda &FC00+drv_svc_addr_lo
+ bne service_driver_addr_retry
+ lda &FC00+drv_svc_addr_mid
+ cmp #&FF
+ bne service_driver_addr_retry
+ lda &FC00+drv_svc_addr_hi
+ cmp #&FF
+ beq service_driver_addr_ok
+.service_driver_addr_retry
+ dex
+ bne service_driver_addr_verify
+ pla
+ tax
+ jmp service_driver_port_missing_near
+.service_driver_addr_ok
+ pla
+ tax
+ pla
+ sta drv_svc_command_copy
+ sta &FC00+drv_svc_data
+ lda #1
+ sta drv_svc_cursor
+ jsr service_driver_wait_cursor
+ \ Rewind byte zero and read it back.  The read auto-increments to byte one,
+ \ which is exactly where callers expect to append their request arguments.
+ lda #0
+ sta &FC00+drv_svc_addr_lo
+ jsr service_driver_bus_settle
+ lda &FC00+drv_svc_data
+ cmp drv_svc_command_copy
+ bne service_driver_port_missing_after_command
+ lda #1
+ sta drv_svc_cursor
+ jsr service_driver_wait_cursor
+ plp
+ rts
+.service_driver_port_missing_near
+ pla
+ plp
+ jmp service_driver_port_missing
+.service_driver_port_missing_after_command
+ plp
+ jmp service_driver_port_missing
+.service_driver_write_y
+ php
+ sei
+ lda drv_svc_cursor
+ sta &FC00+drv_svc_addr_lo
+ jsr service_driver_bus_settle
+ lda #&FF
+ sta &FC00+drv_svc_addr_mid
+ jsr service_driver_bus_settle
+ sta &FC00+drv_svc_addr_hi
+ jsr service_driver_bus_settle
+ tya
+ sta &FC00+drv_svc_data
+ inc drv_svc_cursor
+ jsr service_driver_wait_cursor
+ plp
+ rts
+
+\ Read one response byte through an explicitly selected cursor. The value is
+\ preserved while the asynchronous FCA9 increment is acknowledged.
+.service_driver_read_a
+ lda drv_svc_cursor
+ sta &FC00+drv_svc_addr_lo
+ jsr service_driver_bus_settle
+ lda #&FF
+ sta &FC00+drv_svc_addr_mid
+ jsr service_driver_bus_settle
+ sta &FC00+drv_svc_addr_hi
+ jsr service_driver_bus_settle
+ jsr service_driver_data_settle
+ lda &FC00+drv_svc_data
+ pha
+ inc drv_svc_cursor
+ jsr service_driver_wait_cursor
+ pla
+ rts
+
+\ Selector read-back can precede publication of its FCA9 data byte. Wait using
+\ processor-local instructions only. Reading a FRED register here would post
+\ a newer Pi FIQ event and could destroy the pending selector write.
+.service_driver_data_settle
+ pha
+ txa
+ pha
+ ldx #drv_svc_settle_iterations
+.service_driver_data_settle_loop
+ dex
+ bne service_driver_data_settle_loop
+ pla
+ tax
+ pla
+ rts
+
+\ Do not allow a late FCA9 callback to overwrite the selector for the next
+\ byte. This is bounded so an absent or partially forwarded port still returns.
+.service_driver_wait_cursor
+ jsr service_driver_bus_settle
+ pha
+ txa
+ pha
+ ldx #0
+.service_driver_wait_cursor_loop
+ lda &FC00+drv_svc_addr_lo
+ cmp drv_svc_cursor
+ bne service_driver_wait_cursor_again
+ lda &FC00+drv_svc_addr_mid
+ cmp #&FF
+ bne service_driver_wait_cursor_again
+ lda &FC00+drv_svc_addr_hi
+ cmp #&FF
+ beq service_driver_wait_cursor_done
+.service_driver_wait_cursor_again
+ dex
+ bne service_driver_wait_cursor_loop
+.service_driver_wait_cursor_done
+ pla
+ tax
+ pla
+ rts
+
+\ Allow the FIQ callback to publish selector writes and FCA9 increments.
+\ FRED/JIM reads are not harmless delays: each one posts another bus event.
+\ This helper is private to driver responses; it does not alter WiCFS or WGET.
+.service_driver_bus_settle
+ pha
+ txa
+ pha
+ ldx #drv_svc_settle_iterations
+.service_driver_bus_settle_loop
+ dex
+ bne service_driver_bus_settle_loop
+ pla
+ tax
+ pla
+ rts
+
+.service_driver_dispatch
+ php
+ sei
+ lda #&FF
+ sta &FC00+drv_svc_command
+ jsr service_driver_bus_settle
+ plp
+ lda #0
+ sta drv_svc_timeout_lo
+ lda #1
+ sta drv_svc_timeout_outer
+ \ Association and a real `*LAP` scan are asynchronous. Give those operations
+ \ a long window. Fixed service handlers replace the
+ \ request selector with their own BUSY or final status; an unchanged &FF is
+ \ therefore diagnosed only when the bounded timeout expires.
+ lda drv_svc_command_copy
+ cmp #drv_svc_scan
+ beq service_driver_long_timeout
+ cmp #drv_svc_join
+ beq service_driver_long_timeout
+ cmp #drv_svc_ping
+ beq service_driver_long_timeout
+ cmp #drv_svc_datetime
+ bne service_driver_short_timeout
+.service_driver_long_timeout
+ lda #&FF
+ sta drv_svc_timeout_hi
+ lda #8
+ sta drv_svc_timeout_outer
+ jmp service_driver_wait
+.service_driver_short_timeout
+ lda #100                 \ two seconds at one yield per video frame
+ bne service_driver_set_timeout
+.service_driver_set_timeout
+ sta drv_svc_timeout_hi
+.service_driver_wait
+ lda &FC00+drv_svc_command
+ bpl service_driver_result
+ dec drv_svc_timeout_lo
+ bne service_driver_wait
+ lda drv_svc_command_copy
+ cmp #drv_svc_cancel
+ beq service_driver_wait_yield
+ jsr check_esc
+ bcc service_driver_wait_yield
+ lda #&FF
+ sta drv_svc_cancelled
+ lda #drv_svc_cancel
+ jmp service_driver_begin
+.service_driver_wait_yield
+ lda #19                  \ yield so the Pi cooperative poll can run
+ jsr osbyte
+ dec drv_svc_timeout_hi
+ bne service_driver_wait
+ dec drv_svc_timeout_outer
+ beq service_driver_timeout
+ lda #&FF
+ sta drv_svc_timeout_hi
+ jmp service_driver_wait
+.service_driver_timeout
+ \ An unchanged request selector means no fixed service handler claimed this
+ \ command. Any other negative value is a claimed operation which did not
+ \ complete within its deadline.
+ lda &FC00+drv_svc_command
+ cmp #&FF
+ bne service_driver_timeout_claimed
+ jmp service_driver_service_unclaimed
+.service_driver_timeout_claimed
+ jmp service_driver_no_response
+
+.service_driver_result
+ cmp #0
+ beq service_driver_result_ok
+ jmp service_driver_error
+.service_driver_result_ok
+ lda drv_svc_command_copy
+ cmp #drv_svc_uef_normalize
+ beq service_driver_result_no_copy
+ php
+ sei
+ lda #&FF
+ sta &FC00+drv_svc_addr_hi
+ sta &FC00+drv_svc_addr_mid
+ lda #1
+ sta drv_svc_cursor
+ \ Every implemented service response starts with visible non-space ASCII.
+ \ Reject a floating/unimplemented FCA9 port before relying on JIM paged RAM;
+ \ AP5 open-bus values are commonly &20, &FF or &00.
+ jsr service_driver_read_a
+ cmp #&21
+ bcs service_driver_response_visible
+ plp
+ jmp service_driver_no_response
+.service_driver_response_visible
+ cmp #&7F
+ bcc service_driver_response_ascii
+ plp
+ jmp service_driver_no_response
+.service_driver_response_ascii
+ pha
+ lda #0
+ sta data_pointer
+ lda #240
+ sta drv_svc_response_count
+ ldx #0
+ stx driver_page_shadow
+ pla
+ jsr service_driver_write_paged
+ inx
+ stx data_pointer
+ dec drv_svc_response_count
+.service_driver_copy_response
+ jsr service_driver_read_a
+ beq service_driver_response_done
+ ldx data_pointer
+ jsr service_driver_write_paged
+ inx
+ stx data_pointer
+ dec drv_svc_response_count
+ bne service_driver_copy_response
+ \ A Pi1MHz reply is limited to 239 bytes plus its terminator.  A missing
+ \ terminator usually means an absent service/floating 1MHz bus; never walk
+ \ through 64K of host memory or raise ElkWiFi's misleading Buffer full error.
+ plp
+ jmp service_driver_no_response
+.service_driver_response_done
+ ldx data_pointer
+ lda #0
+ jsr service_driver_write_paged
+ plp
+ jmp restore_env
+
+\ FCFF is shared, write-only AP5 state. Reselect it with interrupts masked for
+\ every response byte so an IRQ-side MMFS/ADFS user cannot redirect the write.
+.service_driver_write_paged
+ php
+ sei
+ pha
+ lda driver_page_shadow
+ jsr select_public_page_a
+ pla
+ sta pageram,x
+ jsr service_driver_bus_settle
+ plp
+ rts
+.service_driver_result_no_copy
+ php
+ sei
+ lda #&FF
+ sta &FC00+drv_svc_addr_hi
+ sta &FC00+drv_svc_addr_mid
+ lda #1
+ sta drv_svc_cursor
+ jsr service_driver_read_a
+ plp
+ rts
+
+.service_driver_error
+ cmp #&42
+ beq service_driver_error_unsupported
+ cmp #&40
+ beq service_driver_error_parameter
+ cmp #&43
+ bne service_driver_error_not_connect
+ lda drv_svc_command_copy
+ cmp #drv_svc_datetime
+ beq service_driver_error_datetime
+ jmp service_driver_error_connect
+.service_driver_error_not_connect
+ cmp #&44
+ beq service_driver_error_no_wifi
+ ldx #(error_no_response-error_table)
+ jmp error
+.service_driver_error_unsupported
+ ldx #(error_not_implemented-error_table)
+ jmp error
+.service_driver_error_parameter
+ ldx #(error_bad_option-error_table)
+ jmp error
+.service_driver_error_connect
+ ldx #(error_opencon-error_table)
+ jmp error
+.service_driver_error_datetime
+ ldx #(error_no_date_time-error_table)
+ jmp error
+.service_driver_error_no_wifi
+ ldx #(error_device_not_found-error_table)
+ jmp error
+
+.service_driver_port_missing
+ \ Address/data read-back failed: FCA6-FCA9 is not being served by Pi1MHz.
+ ldx #(error_device_not_found-error_table)
+ jmp error
+
+.service_driver_service_unclaimed
+ \ The services port echoed the dispatch page but no registered range claimed
+ \ command 80.  This specifically identifies an old/mismatched Pi kernel.
+ ldx #(error_not_implemented-error_table)
+ jmp error
+
+.service_driver_no_response
+ \ Do not communicate this through pageram: when the Pi/JIM service is absent
+ \ there is nowhere for that write to land and generic_cmd prints open-bus
+ \ spaces.  Raise the stock ElkWiFi error directly instead.
+ ldx #(error_no_response-error_table)
+ jmp error

--- a/beeb/1mhz-wifi/src/time.asm
+++ b/beeb/1mhz-wifi/src/time.asm
@@ -1,0 +1,10 @@
+\ Pi1MHz-backed DATE/TIME.  Command 89 obtains UTC from NTP cooperatively;
+\ no external HTTP endpoint or downloadable parser is involved.
+
+.time_cmd
+ jsr service_driver_time
+ jmp generic_response
+
+.date_cmd
+ jsr service_driver_date
+ jmp generic_response

--- a/beeb/1mhz-wifi/src/util.asm
+++ b/beeb/1mhz-wifi/src/util.asm
@@ -1,0 +1,359 @@
+\ util.asm
+\ 1MHz-WiFi ROM: shared helper routines.
+\
+\ Written for the 1MHz-WiFi project, replacing the helper file the ROM
+\ inherited from ElkWiFi 0.23. The entry point names are kept, because they are
+\ the interface every other source file in this ROM calls through and because
+\ short functional names of this kind carry no design of their own. The
+\ implementations below are this project's, and several deliberately differ in
+\ approach from what they replace: the inline string printer walks the string
+\ with the Y register instead of incrementing a pointer per character, the hex
+\ printer folds the nibble with ORA rather than a compare and add pair, and the
+\ string to integer conversion shifts the destination in memory rather than
+\ rolling each bit out of the accumulator.
+\
+\ Where a routine's observable contract was relied on elsewhere it is preserved
+\ exactly, including one inherited quirk that is called out at string2hex.
+
+\ ===========================================================================
+\ Inline string output
+\ ===========================================================================
+\ Prints the string that follows the JSR, and continues at the terminator.
+\
+\   jsr printtext
+\   equs "text",&0D,&EA
+\   ...continues here
+\
+\ The string ends at the first byte with bit 7 set. That byte is not printed;
+\ execution resumes at its address, so &EA is the conventional terminator
+\ because it is also NOP and simply falls through into the code after it.
+\ A, Y and the zero page pointer are not preserved.
+
+.printtext          pla                     \ return address is the last byte
+                    sta zp                  \ of the JSR, one before the text
+                    pla
+                    sta zp+1
+                    ldy #1                  \ so the text starts at offset one
+.printtext_next     lda (zp),y
+                    bmi printtext_done      \ bit 7 set ends the string
+                    tya                     \ OSWRCH is specified to preserve Y,
+                    pha                     \ but a WRCHV claimant might not, and
+                    lda (zp),y              \ every command prints through here
+                    jsr osasci
+                    pla
+                    tay
+                    iny
+                    bne printtext_next
+                    inc zp+1                \ carry into a string over 255 long
+                    jmp printtext_next      \ Y wrapped to zero, keep going
+.printtext_done     tya                     \ resume at the terminator itself
+                    clc
+                    adc zp
+                    sta zp
+                    bcc printtext_go
+                    inc zp+1
+.printtext_go       jmp (zp)
+
+
+\ Print from the Pi reply buffer until a carriage return is printed or the
+\ buffer runs out. The carriage return is printed. Uses read_buffer, so X walks
+\ the buffer and is left after the last byte read.
+
+.print_string       jsr read_buffer         \ Z set means the buffer ended
+                    beq print_string_end
+                    jsr osasci
+                    cmp #&0D
+                    bne print_string
+.print_string_end   rts
+
+
+\ ===========================================================================
+\ Command line parsing
+\ ===========================================================================
+\ Advance Y past spaces on the MOS command line. Enter at skipspace to step
+\ over the current character first, or at skipspace1 to test it. On exit Y
+\ indexes the first non-space character and A holds it.
+
+.skipspace          iny
+.skipspace1         lda (line),y
+                    cmp #' '
+                    beq skipspace
+                    rts
+
+
+\ Copy the next command line parameter into strbuf, terminated with a carriage
+\ return. A parameter ends at a space or at the end of the line. On exit X is
+\ the parameter length, so zero means there was no parameter, and Y indexes the
+\ terminator that ended it.
+
+.read_cli_param     ldx #0
+.read_param_loop    lda (line),y
+                    cmp #&0D
+                    beq read_param_end
+                    cmp #' '
+                    beq read_param_end
+                    sta strbuf,x
+                    iny
+                    inx
+                    cpx #&FF                \ leave room for the terminator
+                    bne read_param_loop
+.read_param_end     lda #&0D
+                    sta strbuf,x
+                    rts
+
+
+\ Append the parameter now in strbuf to the heap parameter block, carriage
+\ return included. X is the heap write offset and must be zero for the first
+\ call; it is left after the terminator so parameters can be appended in turn.
+\ Y is preserved.
+
+.copy_to_heap       sty save_y
+                    ldy #0
+.cth1               lda strbuf,y
+                    iny
+                    sta heap,x
+                    inx
+                    cmp #&0D
+                    bne cth1
+                    ldy save_y
+                    rts
+
+
+\ ===========================================================================
+\ Number conversion and output
+\ ===========================================================================
+\ Print A as two hexadecimal digits. A and Y are not preserved.
+
+.printhex           pha
+                    lsr a
+                    lsr a
+                    lsr a
+                    lsr a
+                    jsr printhex_l1
+                    pla
+.printhex_l1        and #&0F
+                    ora #'0'                \ '0' to '9' land correctly
+                    cmp #'9'+1
+                    bcc printhex_l2
+                    adc #6                  \ carry is set, so this adds seven
+.printhex_l2        jmp osasci
+
+
+\ Convert one ASCII hexadecimal digit in A to its value.
+\ Exit: carry clear, A is the value 0-15; or carry set and A undefined.
+\ Lower case is rejected, as it was before, so that callers which relied on
+\ that rejection to end a parameter still do.
+
+.digit2hex          cmp #'0'
+                    bcc digit2hex_inv
+                    cmp #'9'+1
+                    bcc digit2hex_conv
+                    cmp #'A'
+                    bcc digit2hex_inv
+                    cmp #'F'+1
+                    bcs digit2hex_inv
+                    sec
+                    sbc #'A'-10             \ 'A' becomes ten
+                    clc
+                    rts
+.digit2hex_conv     and #&0F
+                    clc
+                    rts
+.digit2hex_inv      sec
+                    rts
+
+
+\ Convert the hexadecimal string in strbuf to a sixteen bit value in the zero
+\ page pair at X, using &02,X as scratch. Conversion stops at a carriage return
+\ or at the first character that is not a hexadecimal digit.
+\ Exit: X and Y preserved. A is the scratch byte, which callers test against
+\ zero to mean "no address was given".
+\
+\ That test is why &02,X holds the index of the digit being consumed rather
+\ than a count: a single digit at index zero therefore reports A=0. The
+\ behaviour is inherited and is kept deliberately, because *WGET and the sideways
+\ RAM commands rely on a bare "0" being treated as no address.
+
+.string2hex         tya
+                    pha
+                    lda #0
+                    sta &00,x
+                    sta &01,x
+                    sta &02,x
+                    tay
+.string2hex_l1      lda strbuf,y
+                    cmp #&0D
+                    beq string2hex_end
+                    jsr digit2hex
+                    bcs string2hex_end
+                    sty &02,x               \ index survives the shift loop
+                    ldy #4
+.string2hex_l2      asl &00,x               \ make room for the new nibble
+                    rol &01,x
+                    dey
+                    bne string2hex_l2
+                    ora &00,x               \ and merge it in
+                    sta &00,x
+                    ldy &02,x
+                    iny
+                    bne string2hex_l1
+.string2hex_end     pla
+                    tay
+                    lda &02,x
+                    rts
+
+
+\ ===========================================================================
+\ Reply buffer searching
+\ ===========================================================================
+\ Search the JIM reply buffer for the string at needle, of length size, from
+\ the current read position X.
+\ Exit: carry set and X just past the match; or carry clear at end of buffer.
+\ A and Y are undefined.
+
+.fnd                ldy #0
+.fnd1               jsr read_buffer
+                    beq fnd_not_found
+                    cmp (needle),y
+                    bne fnd                 \ mismatch, start the match again
+                    iny
+                    cpy size
+                    bne fnd1
+                    sec
+                    rts
+.fnd_not_found      clc
+                    rts
+
+
+\ Test whether the two buffer bytes at X are "OK", without consuming them.
+\ Exit: Z set if they are. A and X preserved.
+\ X is not allowed to be 255 here, which no caller does: the second byte would
+\ wrap to the start of the window rather than reading past its end.
+
+.test_ok            pha
+                    lda pageram,x
+                    cmp #'O'
+                    bne test_ok_end
+                    lda pageram+1,x
+                    cmp #'K'
+.test_ok_end        pla
+                    rts
+
+
+\ Test whether the next three buffer bytes are "ERR", consuming them.
+\ Exit: Z set if they are. A undefined; X is left wherever the test stopped.
+
+.test_error         pha
+                    jsr read_buffer
+                    cmp #'E'
+                    bne test_error_end
+                    jsr read_buffer
+                    cmp #'R'
+                    bne test_error_end
+                    jsr read_buffer
+                    cmp #'R'
+.test_error_end     pla
+                    rts
+
+
+\ Advance X past the next line feed in the buffer.
+\ Exit: Z set if the buffer ended first, clear if a line feed was found.
+
+.search0a           jsr read_buffer
+                    beq search0a_l1
+                    cmp #&0A
+                    bne search0a
+                    cmp #&0D                \ any unequal value clears Z
+.search0a_l1        rts
+
+
+\ ===========================================================================
+\ Housekeeping
+\ ===========================================================================
+\ Restore the X and Y a service call entry pushed, and claim the call.
+
+.call_claimed       pla
+                    tax
+                    pla
+                    tay
+                    lda #&00
+                    rts
+
+
+\ Report whether Escape is pending, acknowledging it if so.
+\ Exit: carry set if Escape was pressed. A, X and Y are preserved.
+
+.check_esc
+if __ELECTRON__
+                    bit &FF
+                    bmi esc_pressed
+                    clc
+                    rts
+.esc_pressed        lda #126
+                    jsr osbyte
+                    sec
+                    rts
+else
+                    rts
+endif
+
+
+\ Wait for two vertical syncs, to pace polling without burning the bus.
+
+.wait
+if __ELECTRON__
+                    pha
+                    lda #19
+                    jsr osbyte
+                    jsr osbyte
+                    pla
+else
+                    jsr &FE66
+                    jsr &FE66
+endif
+                    rts
+
+
+\ ===========================================================================
+\ Startup banner glyph
+\ ===========================================================================
+\ Define and print the signal icon that precedes the banner text.
+\
+\ The ROM this project started from poked the glyph straight into screen
+\ memory at &60A0, which pinned it to row zero while the banner itself followed
+\ the boot cursor. Defining character 255 and printing it through the VDU keeps
+\ the icon on the banner's own line whatever the ROM ordering and however the
+\ screen has scrolled.
+\
+\ The BBC B, B+ and Master boot into MODE 7, where characters above 127 are
+\ teletext codes rather than soft characters, so a defined glyph cannot be
+\ displayed and VDU 255 would emit a stray graphics cell instead. Only the
+\ Electron, which has no teletext mode, ever reaches the glyph. The banner
+\ text is identical on all four machines either way.
+
+if __ELECTRON__
+.print_logo         lda #135                \ OSBYTE 135 returns the mode in Y
+                    jsr osbyte
+                    cpy #7                  \ teletext cannot show a soft
+                    beq logo2               \ character, so print none
+                    lda #' '
+                    jsr oswrch
+                    lda #23                 \ VDU 23,255,... defines a glyph
+                    jsr oswrch
+                    lda #255
+                    jsr oswrch
+                    ldx #0
+.logo1              lda wifi_symbol,x
+                    jsr oswrch
+                    inx
+                    cpx #8
+                    bne logo1
+                    lda #255                \ and print it
+                    jsr oswrch
+.logo2              rts
+else
+.print_logo         rts
+endif
+
+\ Two arcs over a point, drawn for this ROM.
+.wifi_symbol        equb &3C,&42,&18,&24,&00,&18,&18,&00

--- a/beeb/1mhz-wifi/src/version.asm
+++ b/beeb/1mhz-wifi/src/version.asm
@@ -1,0 +1,34 @@
+\ 1MHz-WiFi version and shared simple-command response handler.
+
+\ Syntax: *VERSION
+
+.version_cmd
+  jsr printtext
+ equs "1MHz-WiFi 0.1.67 (C) 2026 Peter Clarke",&0D
+  equs "Parts from ElkWiFi (C) 2020 Roland Leurs",&0D,&EA
+
+  \ Print the Pi1MHz service version after the two ROM attribution lines.
+  lda #2
+
+.generic_cmd
+  jsr wifidriver
+.generic_response
+  jsr reset_buffer
+  jsr read_buffer
+  beq no_device
+  dex
+.version_l2
+  jsr read_buffer
+  jsr oswrch
+  lda datalen+1
+  cmp driver_page_shadow
+  bne version_l2
+  cpx datalen
+  bne version_l2
+
+.version_end
+  jmp call_claimed
+
+.no_device
+  ldx #(error_no_response-error_table)
+  jmp error

--- a/beeb/1mhz-wifi/src/wget.asm
+++ b/beeb/1mhz-wifi/src/wget.asm
@@ -1,0 +1,127 @@
+\ Helpers shared by the Pi1MHz WGET implementation.
+\ The inherited UART/AT-command downloader is deliberately not emitted.
+
+proto = heap+&F5
+newln = heap+&F6
+clptr = heap+&F7
+index = heap+&F8
+sflag = heap+&F9
+tflag = heap+&FA
+aflag = heap+&FB
+pflag = heap+&FC
+uflag = heap+&FD
+laddr = heap+&FE
+
+.wget_context_switch_in
+ php
+ sei
+ pha
+ lda net_primary_page
+ sta load_addr+1
+ jsr set_bank_1
+ lda pr_r
+ sta pagereg
+ jsr bus_delay
+ ldy pr_y
+ pla
+ plp
+ rts
+
+.wget_context_switch_out
+ php
+ sei
+ pha
+ sty pr_y
+ jsr set_bank_0
+ lda load_addr+1
+ sta net_primary_page
+ sta pagereg
+ jsr bus_delay
+ pla
+ plp
+ rts
+
+.wget_copy_file_to_swr
+ ldy #(wget_swramload_end-wget_swramload)
+.wget_copy_file_l1
+ lda wget_swramload,y
+ sta heap,y
+ dey
+ bpl wget_copy_file_l1
+ jsr wget_context_switch_in
+ jsr heap
+ jsr wget_context_switch_out
+ rts
+
+.wget_swramload
+ lda #&81
+ ldx #0
+ ldy #&FF
+ jsr osbyte
+ stx zp+5
+ lda laddr
+ and #&0F
+ pha
+ ldx zp+5
+ cpx #1
+ bne wget_swram_select_bbc
+ lda #&0C
+ sta &FE05
+ pla
+ sta &FE05
+ jmp wget_swram_selected
+.wget_swram_select_bbc
+ pla
+ sta &FE30
+.wget_swram_selected
+ sei
+ ldx #0
+ stx pr_r
+ stx pagereg
+ stx zp+2
+ lda #&80                  \ sideways RAM starts at &8000
+ sta zp+3
+ lda #&40                  \ and is 64 pages long
+ sta zp+4
+ ldy #0
+.wget_swramload_l1
+ lda pageram,y
+ sta (zp+2),y
+ cmp (zp+2),y              \ read back: absent RAM will not hold the write
+ bne wget_swramload_err
+ iny
+ bne wget_swramload_l1
+ inc pr_r
+ lda pr_r
+ sta pagereg
+ jsr bus_delay
+ inc zp+3
+ dec zp+4
+ bne wget_swramload_l1
+ lda shadow
+ ldx zp+5
+ cpx #1
+ bne wget_swram_restore_bbc
+ sta &FE05
+ jmp wget_swram_restored
+.wget_swram_restore_bbc
+ sta &FE30
+.wget_swram_restored
+ cli
+ rts
+
+.wget_swramload_err
+ lda shadow
+ ldx zp+5
+ cpx #1
+ bne wget_swram_error_restore_bbc
+ sta &FE05
+ jmp wget_swram_error_restored
+.wget_swram_error_restore_bbc
+ sta &FE30
+.wget_swram_error_restored
+ cli
+ brk
+ equb 0
+ equs "Not swram",0
+.wget_swramload_end

--- a/beeb/1mhz-wifi/src/wificmd.asm
+++ b/beeb/1mhz-wifi/src/wificmd.asm
@@ -1,0 +1,56 @@
+\ wificmd.asm
+\ 1MHz-WiFi ROM: *WIFI.
+\
+\ Written for the 1MHz-WiFi project. The command keeps the ElkWiFi syntax
+\ because that is the interface users and scripts already have, but the parser
+\ and the response handling are this project's and talk to the Pi1MHz service
+\ driver. Attribution for what genuinely derives from ElkWiFi is carried in
+\ *VERSION.
+\
+\ Syntax: *WIFI [ON | OFF | SR | HR]
+
+.wifi_cmd       lda (line),y
+                cmp #&0D
+                beq wifi_badcmd
+                jsr skipspace
+                cmp #'O'
+                beq wifi_on_off
+                cmp #'S'
+                beq wifi_sr
+                cmp #'H'
+                beq wifi_hr
+.wifi_badcmd    jmp wifi_help
+
+.wifi_hr        ldx #1
+                bne wifi_reset
+
+.wifi_sr        ldx #0
+.wifi_reset     iny
+                lda (line),y
+                cmp #'R'
+                bne wifi_badcmd
+                jmp service_driver_unsupported
+
+.wifi_on_off    jsr skipspace
+                cmp #'N'
+                beq wifi_on
+                cmp #'F'
+                bne wifi_badcmd
+
+.wifi_off       jsr printtext
+                equs "Switching wifi off",&0D,&EA
+                ldx #0
+.wifi_off_l1    lda #24
+                jmp generic_cmd             \ print WIFI OFF/ready state and final OK
+
+.wifi_on        jsr printtext
+                equs "Switching wifi on",&0D,&EA
+                ldx #1
+                bne wifi_off_l1
+
+.wifi_help      jsr printtext
+                equs " ON   enable wifi",&0D
+                equs " OFF  disable wifi",&0D
+                equs " SR   not implemented",&0D
+                equs " HR   not implemented",&0D,&EA
+                jmp call_claimed


### PR DESCRIPTION
The host half of `wifi_service`. This is the sideways ROM that provides the
star commands and the OSWORD `&65` entry that applications call, against the
services already in this repository.

It is one new directory, `beeb/1mhz-wifi/`. No existing file is touched,
nothing is added under `src/` or `CMakeLists.txt`, and nothing references the
directory, so the firmware build cannot be affected by it. Build it with
`beeb/1mhz-wifi/build.sh`, which needs beebasm and writes a 16,384 byte image.

## Why it should work against plain master

You took the WiFi service when you merged the earlier work, and the ROM is the
client for it, so I checked the interface rather than assuming it.

The command numbers in `src/wifi_service.h` are identical to the ones this ROM
sends: 80 status, 81 scan, 82 join, 83 ifcfg, 86 guard, 87 lapopt, 88 ping, 89
datetime, 90 cancel, 91 radio, 92 online, 93 uef. All thirteen match.

The reply format matches too, which is the part that would break quietly if it
did not. `wifi_service.c` answers ping with `+<ms>\r\n` or `+timeout\r\n`, and
`src/ping.asm` reads the `+`, then tests the next byte for `t` to distinguish a
timeout from a time. That sentinel is distinctive enough to be worth stating as
evidence rather than as an assurance.

What I have not done is run this ROM against a kernel built from this branch.
The emulator results below exercise the ROM against the project's own emulation
of the service, not against your C. If you want that closed before merging, say
so and I will do it rather than leave it implied.

## FTP is deliberately absent

The host side of `*FTP` exists downstream, but `ftp_service` is not in this
repository, so shipping the command here would give users a command with
nothing to answer it. I removed it from the offering rather than document a
dead entry. It can follow if you want the service; that is your call, not
something to smuggle in with a ROM.

## RAM disk

The ROM carries a RAM disk: 65,024 bytes in up to 15 files in the low 64 KiB
JIM window, so a program can be fetched over the network and run with no
filing system fitted.

It stays in bank 0. That is the only bank an unmodified Electron AP5 forwards,
so a format using `&FCFD` and `&FCFE` would work on the BBC family and
silently not on the Electron. Page 0 is left alone because that is the OSWORD
`&65` reply buffer. Files are page aligned, so a short file costs a whole page,
and space comes back only through `*RDINIT`. Those are the two behaviours a
user will notice, so they are in the README rather than left to be discovered.

## Machine coverage

One image, four machines, decided at run time with OSBYTE `&81`: `&FE05` with
the Electron deselect cycle against `&FE30` for sideways ROM selection, and
whether the JIM selectors need reasserting per transaction.

The banner glyph is a soft character, and the BBC family boots into MODE 7
where codes above 127 are teletext cells, so the ROM reads the mode with OSBYTE
135 and omits the glyph there. Without that the three BBC machines emitted a
stray graphics cell where the Electron showed the icon.

## Verification

Emulator only. None of this is physical hardware validation.

Elkulator, Electron, through the project's own mailbox integration: full
TELNET and SSH mailbox smoke tests pass with the Tube disabled and enabled.

B-Em at `ccddf9f`, mailbox model `live`, one private Xvfb per run, profiles
`bbc-b-32k` on OS 1.20, `bbc-b-plus`, and `master-128` on MOS 3.20. All three
print the banner and answer `*VERSION`; `*HELP WIFI` renders the full command
list on the Master; and the RAM disk round trips, with a BBC B cataloguing
`HELLO 3000 3020 0100` after a save with an execution address, and a Master
saving a kilobyte as `0400` across four pages and loading it back to a
different address.

The image offered here is 16,384 bytes, SHA-256
`63f4dc328e34f95d430123ab7914d4d597e76aa8763cee012b23c4d0a17d5590`, content
ending at `&A39B` with 7,013 bytes free below the `&BF00` ceiling. It differs
from the image in those emulator runs only by the removal of `*FTP`.

## Provenance

Every file is original to the 1MHz-WiFi project and carries no ElkWiFi or
UPCFS lineage. That is recent and deliberate: the ROM previously contained
code from Roland Leurs' ElkWiFi 0.23, Martin Barr's UPCFS by way of the
cassette filing system, and Gerrit Hillebrand's ATOM GDOS 1.5 in the command
table search. None of those authors has stated licence terms, so the inherited
material was rewritten or moved into a second image that is not offered here.
That is what makes this ROM something I can offer you at all.

`*VERSION` credits ElkWiFi for the interface this ROM implements. I have not
removed that and would not.

## One thing I have not assumed

I have not added the built ROM to `firmware/Pi1MHz/`. Doing so would put 16 KiB
in every user's bundle, which is your decision rather than mine. Say the word
and I will add it and the `Pi1MHz.cfg` line, or leave it as source.
